### PR TITLE
🐛 [fix] #13 중첩된 ObservableObject의 @Published showOnboarding값 변경을 감지하지 못하는 문제 해결

### DIFF
--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -42,18 +42,21 @@ class CameraViewModel: ObservableObject {
     @Published var lastZoomInteraction = Date() // 줌 슬라이더 타이머 로직을 위해 유지
 
     // MARK: - Core Dependencies & Models
-     var model: CameraManager
+
+    var model: CameraManager
     private let swiftDataManager = SwiftDataManager.shared
     @Published var tiltCollector = TiltDataCollector()
+    @Published var showOnboarding: Bool = false
 
     // MARK: Internal State
+
     let session: AVCaptureSession
     let videoSavedPublisher = PassthroughSubject<URL, Never>()
     var timeStampedTiltList: [TimeStampedTilt] = []
 
     private var cancellables = Set<AnyCancellable>()
     private var horizontalLevelCancellable: AnyCancellable?
-    
+
     // Private Timers
     private var feedbackTimer: Timer?
     private var zoomSliderAutoHideTimer: Timer?
@@ -71,10 +74,12 @@ class CameraViewModel: ObservableObject {
     private var hasRequiredPermissions: Bool { model.permissionState == .both }
 
     // MARK: - init
+
     init() {
         model = CameraManager()
         session = model.session
-
+        model.$showOnboarding
+            .assign(to: &$showOnboarding)
         model.$isRecording
             .assign(to: &$isRecording)
 


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #13 

## ✨ PR Content
> 온보딩 완료 후 권한 요청 시트가 표시되지 않던 문제를 해결했습니다.


## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

## 📍 PR Point 
> 
#9 여기서 크게 머지되는 과정에서 약간의 변경사항이 있었던 것 같습니다 ! 


  ```swift
  class CameraViewModel: ObservableObject {
      var model: CameraManager  
  }

  class CameraManager: ObservableObject {
      @Published var showOnboarding = false
  }
```

`ViewModel`에서 `showOnBoarding`을 `assign`을 통해서 강제로 온보딩여부를 관찰할 수 있게 했습니다. 

```swift
class CameraViewModel: ObservableObject {
      var model: CameraManager
      @Published var showOnboarding = false 

      init() {
          model = CameraManager()
          // CameraManager의 showOnboarding 변경을 ViewModel에 전파
          model.$showOnboarding.assign(to: &$showOnboarding)
      }
  }
```

- 특이 사항 1
 - 당장은 이렇게 해줬지만, `CameraManager`가 `Viewmodel`에서 생성되고 있는 구조가 생명 주기가 ViewModel에 종속되어있는게 아무래도 불안정한 것 같네요. 방금처럼 중첩되어서 일어나는 문제들도 있구요. 다음번엔 이걸 `CameraView`에서 각자 생성해주는게 더 이상적으로 보여서 한번 조정을 해보겠습니다. 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
