### PR TITLE
✨ [feat] GoogleAnalytics 내부 트래픽 필터링 구현

### DIFF
--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -7,6 +7,7 @@
 
 import AdSupport
 import AppTrackingTransparency
+import FirebaseAnalytics
 import FirebaseCore
 import SwiftData
 import SwiftUI
@@ -147,13 +148,17 @@ struct ChalkakApp: App {
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        
+        FirebaseApp.configure()
+        
+        configureAnalyticsUserType()
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             ATTrackingManager.requestTrackingAuthorization { status in
                 switch status {
                 case .authorized:
                     print("Authorized")
                     print("IDFA = \(ASIdentifierManager.shared().advertisingIdentifier)")
-                    FirebaseApp.configure()
                 case .denied:
                     print("Denied")
                 case .notDetermined:
@@ -166,5 +171,23 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             }
         }
         return true
+    }
+    
+    private func configureAnalyticsUserType() {
+        #if DEBUG
+        Analytics.setUserProperty("internal traffic", forName: "traffic_type")
+        
+        #else
+        if isTestFlight() {
+            Analytics.setUserProperty("internal traffic", forName: "traffic_type")
+        } else {
+            Analytics.setUserProperty("external traffic", forName: "traffic_type")
+        }
+        #endif
+    }
+
+    private func isTestFlight() -> Bool {
+        guard let receiptURL = Bundle.main.appStoreReceiptURL else { return false }
+        return receiptURL.lastPathComponent == "sandboxReceipt"
     }
 }


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #37

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

Google Anaytics 활성 상태 분석 시점에 팀 내부 트래픽을 실 사용자 트래픽과 구분하기 위한 필터링을 추가했습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

<img width="1527" height="366" alt="Screenshot 2026-01-09 at 12 14 46 AM" src="https://github.com/user-attachments/assets/4e2ff0a3-3dec-4bc0-a976-8fd0ceb50261" />

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- Google Anaytics 사용 방식
Dashboard에서 필터링을 걸어서 내부 트래픽 포함 / 내부만 / 내부 제외 3가지를 모두 확인할 수 있습니다.
traffic_type 을 속성으로 가지며, 해당 값이 internal_traffic 이면 내부, external_traffic이면 실 사용자, 조건 X으면 모두의 기록을 확인할 수 있습니다.
필터링 비교 조건으로 아예 추가해둔 상태이니, 지정만 해주시면 됩니다.

- 특이 사항 2

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
