### PR TITLE
✨ [feat] #47 촬영 중 이탈 버튼 숨김 처리

### DIFF
--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -29,7 +29,6 @@ struct CameraView: View {
     @State private var navigateToEdit = false
     @State private var feedbackOpacity: Double = 0
     @State private var fadeOutTask: Task<Void, Never>?
-    @State private var showExitAlert = false
 
     var body: some View {
         ZStack {
@@ -38,7 +37,7 @@ struct CameraView: View {
             } else {
                 SnappieColor.darkHeavy.edgesIgnoringSafeArea(.all)
             }
-            
+
             ZStack {
                 CameraPreviewView(
                     session: viewModel.session,
@@ -51,7 +50,7 @@ struct CameraView: View {
                 )
                 .aspectRatio(9 / 16, contentMode: .fit)
                 .clipped()
-                
+
                 // 타이머 설정 오버레이
                 if viewModel.showTimerFeedback != nil {
                     Text("\(viewModel.showTimerFeedback!.rawValue)")
@@ -59,7 +58,7 @@ struct CameraView: View {
                         .foregroundColor(SnappieColor.labelPrimaryNormal)
                         .opacity(feedbackOpacity)
                 }
-                
+
                 // 타이머 카운트다운 오버레이
                 if viewModel.isTimerRunning && viewModel.timerCountdown > 0 {
                     Text("\(viewModel.timerCountdown)")
@@ -85,7 +84,7 @@ struct CameraView: View {
                     size: .large,
                     isActive: true
                 )) {
-                    showExitAlert = true
+                    handleExitCamera()
                     Analytics.logEvent("exitCameraAlertTapped", parameters: nil)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -111,7 +110,7 @@ struct CameraView: View {
                     do {
                         // 대기 1초
                         try await Task.sleep(nanoseconds: 700_000_000)
-                        
+
                         // 태스크가 취소되지 않았다면 페이드아웃
                         if !Task.isCancelled {
                             withAnimation(.easeOut(duration: 0.3)) {
@@ -128,7 +127,7 @@ struct CameraView: View {
         .onReceive(viewModel.videoSavedPublisher) { url in
             self.clipUrl = url
             viewModel.saveCameraSettings()
-            
+
             coordinator.push(.clipEdit(
                 clipURL: url,
                 state: shootState,
@@ -165,18 +164,9 @@ struct CameraView: View {
         .onDisappear {
             viewModel.stopCamera()
         }
-        .alert("촬영을 마치고 나갈까요?", isPresented: $showExitAlert) {
-            Button("취소", role: .cancel) {}
-            Button("나가기", role: .destructive) {
-                handleExitCamera()
-                Analytics.logEvent("exitCameraButtonTapped", parameters: nil)
-            }
-        } message: {
-            Text("지금까지 찍은 장면은 저장돼요.")
-        }
         .snappieAlert(isPresented: $viewModel.showProjectSavedAlert, message: "프로젝트가 저장되었습니다")
     }
-    
+
     private func handleExitCamera() {
         viewModel.stopCamera()
 


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #47 

## ✨ PR Content
>
- `if !viewModel.isRecording` 조건으로 이탈버튼이 조건에따라 렌더링이 되게끔 수정하였습니다.
- V+HStack과 Spacer()로 위치잡아주던것 대신에 `algnment: .topLeading`으로 변경하여 쓸모없는 Stack 구조를 제거하였습니다.


## 📸 Screenshot

### 녹화시 이탈버튼 제거
https://github.com/user-attachments/assets/b71032c3-ebf7-4ced-bbb2-12d0fb976e4f

### 이탈버튼 Alert 제거
https://github.com/user-attachments/assets/16e8ab1b-7660-45f1-b66e-c4594e201de5


## 📍 PR Point 
> `CameraViewModel`이 유독 경계업싱 복잡하게 되어있네요. 
- viewModel은 이번 QA끝나고 다듬도록 하겠습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
