### PR TITLE
💄 [style] ControlPanel 중앙 텍스트 길이에 따른 버튼 위치 변경 이슈 개선

### DIFF
--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
@@ -95,18 +95,19 @@ struct GuideSelectView: View {
                     Divider()
                         .foregroundStyle(Color.deepGreen50.opacity(0.1))
 
-                    HStack {
+                    ZStack(alignment: .center) {
                         Text("00:00")
                             .font(SnappieFont.style(.roundCaption1))
                             .foregroundStyle(SnappieColor.primaryHeavy)
-
-                        Spacer()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 24)
 
                         Text((clip.endPoint - clip.startPoint).formattedTime)
                             .font(SnappieFont.style(.roundCaption1))
                             .foregroundStyle(SnappieColor.primaryHeavy)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                            .padding(.trailing, 24)
                     }
-                    .padding(.horizontal, 24)
                     // 하단 썸네일 부분
                     GuideFrameSelectorView(editViewModel: editViewModel, isDragging: $isDragging)
                         .padding(.horizontal, 26)

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
@@ -35,38 +35,47 @@ struct VideoControlPanelView: View {
     let showOverlayToggle: Bool
 
     var body: some View {
-        HStack(alignment: .center, spacing: 108) {
+        ZStack(alignment: .center) {
             SnappieButton(
                 .iconBackground(
-                    icon: editViewModel.isPlaying ? .pauseFill : .playFill,
+                    icon: self.editViewModel.isPlaying ? .pauseFill : .playFill,
                     size: .medium,
                     isActive: true
                 )
             ) {
-                editViewModel.togglePlayback()
+                self.editViewModel.togglePlayback()
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 24)
 
-            Text(String(format: "%.2f초", editViewModel.currentTrimmedDuration))
-                .font(SnappieFont.style(.proLabel3))
-                .foregroundStyle(SnappieColor.labelDarkNormal)
-                .padding(.horizontal, 9.5)
-                .padding(.vertical, 6)
-                .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(SnappieColor.primaryStrong)
-                )
+            HStack(alignment: .center) {
+                Spacer()
+
+                Text(String(format: "%.2f초", self.editViewModel.currentTrimmedDuration))
+                    .font(SnappieFont.style(.proLabel3))
+                    .foregroundStyle(SnappieColor.labelDarkNormal)
+                    .padding(.horizontal, 9.5)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(SnappieColor.primaryStrong)
+                    )
+
+                Spacer()
+            }
 
             SnappieButton(
                 .iconBackground(
                     icon: .silhouette,
                     size: .medium,
-                    isActive: showOverlayToggle ? isOverlayVisible : false
+                    isActive: self.showOverlayToggle ? self.isOverlayVisible : false
                 )
             ) {
-                isOverlayVisible.toggle()
+                self.isOverlayVisible.toggle()
             }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.trailing, 24)
         }
-        .padding(.horizontal, 23)
     }
 }
 


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #50

## ✨ PR Content
> `GuideSelectView`, `ClipEditView`의 ControlPannel의 디자인을 수정하여 시간 표시 길이에 따라 간격이 변경되지않게끔 조정하였습니다. 


## 📸 Screenshot

https://github.com/user-attachments/assets/09fe2798-5e56-4b13-8c44-4f6be78d3aae



## 📍 PR Point 
> `GuideSelectView`와 `ClipEditView` 스타일은 추후에 공통 컴포넌트로 빼서 활용할 수 있게 하겠습니다

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
