### PR TITLE
✨ [feat] 클립 가이드인 경우 배지 표시

### DIFF
--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -82,6 +82,7 @@ struct ProjectEditView: View {
                 selectedClipID: $viewModel.selectedClipID,
                 isPlaying: viewModel.isPlaying,
                 totalDuration: viewModel.totalDuration,
+                guideClipID: viewModel.guide?.clipID,
                 onSeek: viewModel.seekTo,
                 onMove: viewModel.moveClip,
                 onAddClipTapped: {

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -614,7 +614,7 @@ final class ProjectEditViewModel {
         }
         for (idx, originalClip) in originalOrdered.enumerated() {
             let tempClip = Clip(
-                id: "temp_\(UUID().uuidString)",
+                id: "temp_\(originalClip.id)",
                 videoURL: originalClip.videoURL,
                 originalDuration: originalClip.originalDuration,
                 startPoint: originalClip.startPoint,

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ClipTrimmingView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ClipTrimmingView.swift
@@ -14,6 +14,7 @@ struct ClipTrimmingView: View {
     let isReordering: Bool
     let onDragStateChanged: (Bool) -> Void
     let onTap: () -> Void
+    let isGuideClip: Bool
 
     private let clipWidth: CGFloat = 62
     private let clipHeight: CGFloat = 97
@@ -35,17 +36,18 @@ struct ClipTrimmingView: View {
                             .padding(.bottom, 8)
                     }
                     .overlay(alignment: .topLeading) {
-                        // TODO: 가이드가 있는 클립일 경우 아래 주석의 실루엣 배지 띄우기
-//                        Image("silhouette")
-//                            .resizable()
-//                            .scaledToFit()
-//                            .frame(width: 12, height: 12)
-//                            .padding(2)
-//                            .background(
-//                                Circle()
-//                                    .fill(SnappieColor.labelDarkNormal)
-//                            )
-//                            .padding(4)
+                        if isGuideClip {
+                            Image("silhouette")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 12, height: 12)
+                                .padding(2)
+                                .background(
+                                    Circle()
+                                        .fill(SnappieColor.labelDarkNormal)
+                                )
+                                .padding(4)
+                        }
                         
                     }
             } else {

--- a/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/ProjectTimelineView.swift
@@ -11,6 +11,7 @@ struct ProjectTimelineView: View {
     @Binding var clips: [EditableClip]
     @Binding var isDragging: Bool
     @Binding var selectedClipID: String?
+    let guideClipID: String?
     let playHeadPosition: Double
     let totalDuration: Double
     let dragOffset: CGFloat
@@ -59,7 +60,8 @@ struct ProjectTimelineView: View {
                             isSelected: selectedClipID == clip.id,
                             isReordering: isDragActive,
                             onDragStateChanged: onDragStateChanged,
-                            onTap: { onClipTapped(clip.id) }
+                            onTap: { onClipTapped(clip.id) },
+                            isGuideClip: guideClipID == clip.id
                         )
                         .frame(width: isBeingDragged ? 0.0 : clipWidth, height: clipHeight)
                         .opacity(isBeingDragged ? 0.0 : 1.0)
@@ -117,7 +119,8 @@ struct ProjectTimelineView: View {
                         isSelected: selectedClipID == draggingClip.id,
                         isReordering: isDragActive,
                         onDragStateChanged: onDragStateChanged,
-                        onTap: { onClipTapped(draggingClip.id) }
+                        onTap: { onClipTapped(draggingClip.id) },
+                        isGuideClip: guideClipID == draggingClip.id
                     )
                     .frame(width: clipWidth, height: clipHeight)
                     .scaleEffect(scaleDuringDrag, anchor: .center)

--- a/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
+++ b/Chalkak/Presentation/ProjectEdit/SubViews/TrimmingLineSliderView.swift
@@ -14,6 +14,7 @@ struct TrimminglineSliderView: View {
     @Binding var selectedClipID: String?
     let isPlaying: Bool
     let totalDuration: Double
+    let guideClipID: String?
 
     let onSeek: (Double) -> Void
     let onMove: (IndexSet, Int) -> Void
@@ -38,6 +39,7 @@ struct TrimminglineSliderView: View {
                 clips: $clips,
                 isDragging: $isDragging,
                 selectedClipID: $selectedClipID,
+                guideClipID: guideClipID,
                 playHeadPosition: playHeadPosition,
                 totalDuration: totalDuration,
                 dragOffset: dragOffset,


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Closes #44 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

- 가이드가 포함된 클립인 경우에 가이드 배지를 표시합니다 
- tempClip을 만드는 과정에서 tempGuide의 clipID와 불일치하는 이슈가 있어서 클립 아이디와 일치시킬 수 있도록 기존의 클립아이디를 활용해 임시클립의 ID를 생성하는 방식으로 수정 구현하였습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

<img height="500" alt="스크린샷, 2026-01-15 오후 9 54 13" src="https://github.com/user-attachments/assets/efd81986-2de0-4432-9219-ee1a574b6c61" />

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

가이드 클립 배지 기능을 작업하면서 ID 매칭 관련 이슈를 발견했습니다.
#### 기존 상황
- tempGuide: 원본 ID 기반으로 생성 (`temp_{originalProject.guide.clipID}`)
- tempClip: 새로운 UUID 생성 (`temp_{UUID().uuidString}`)

```swift
// tempGuide 생성
let tempGuide = Guide(
    clipID: "temp_\(originalProject.guide.clipID)",
    ...
)


// tempClip 생성
let tempClip = Clip(
    id: "temp_\(UUID().uuidString)",  // 👈 여기입니닷
    videoURL: originalClip.videoURL,
    originalDuration: originalClip.originalDuration,
    ...
)
```
#### 문제점
tempGuide의 clipID와 tempClip의 id가 서로 매칭되지 않아 가이드 클립 배지가 제대로 표시되지 않는 상황입니다.

#### 현재 해결한 방법
tempClip도 tempGuide처럼 원본 ID 기반으로 생성했는데요, 임시 프로젝트여서 저장이나, 편집같은 다른 영역에 문제가 생기지 않는 점은 확인하였습니다.
```swift
let tempClip = Clip(
    id: "temp_\(originalClip.id)",  // UUID() 대신 originalClip.id 활용
    ...
)
```
#### 질문

- tempClip ID를 처음 작업하실 때 새로운 UUID를 생성하신 특별한 이유가 있으셨나요?
- 나머지 아규먼트들은 모두 originalClip의 정보를 그대로 사용하고 있는데, ID만 새로 생성한 것도 의도가 있으셨을까요?
- temp 관련 부분이라 변경해도 기존 로직에는 영향이 없을 것 같은데, 혹시 제가 놓친 부분이 있을까요?

의견 부탁드립니다! 🙏

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
