### PR TITLE
🐛 [Fix] 추가 촬영 시점에 tilt guide 멈추는 문제 해결

### DIFF
--- a/Chalkak/Core/Guide/Tilt/TiltDataCollector.swift
+++ b/Chalkak/Core/Guide/Tilt/TiltDataCollector.swift
@@ -27,6 +27,7 @@ class TiltDataCollector: ObservableObject {
     // MARK: - Properties
     /// CoreMotion 데이터를 수집하는 모션 매니저
     private var motionManager = CMMotionManager()
+    private let motionQueue = OperationQueue()
 
     /// 디바이스가 좌우로 기울어진 정도
     @Published var gravityX: Double = 0.0
@@ -34,24 +35,34 @@ class TiltDataCollector: ObservableObject {
     /// 디바이스가 앞뒤로 기울어진 정도
     @Published var gravityZ: Double = 0.0
 
-    // MARK: - init
-    /// TiltDataCollector를 초기화하고 CoreMotion 데이터 수집을 시작합니다.
     init() {
-        // 디바이스 모션 업데이트 시작
-        if motionManager.isDeviceMotionAvailable {
-            motionManager.deviceMotionUpdateInterval = 1.0 / 60.0  // 1초에 60번(60FPS)
-            motionManager.startDeviceMotionUpdates(to: .main) {
-                [weak self] (data, error) in
-                guard let self = self, let data = data else { return }
+        motionQueue.name = "TiltMotionQueue"
+        motionQueue.qualityOfService = .userInteractive
+    }
+    
+    // 디바이스 모션 업데이트 시작
+    func start() {
+        guard motionManager.isDeviceMotionAvailable else { return }
+        guard !motionManager.isDeviceMotionActive else { return }
 
+        motionManager.deviceMotionUpdateInterval = 1.0 / 60.0
+        motionManager.startDeviceMotionUpdates(to: motionQueue) { [weak self] data, _ in
+            guard let self, let data else { return }
+
+            DispatchQueue.main.async {
                 self.gravityX = data.gravity.x
                 self.gravityZ = data.gravity.z
             }
         }
     }
     
+    func stop() {
+        guard motionManager.isDeviceMotionActive else { return }
+        motionManager.stopDeviceMotionUpdates()
+    }
+    
     /// TiltDataCollector가 해제될 때 motion updates를 자동으로 중지하도록 처리
     deinit {
-        motionManager.stopDeviceMotionUpdates()
+        stop()
     }
 }

--- a/Chalkak/Core/Guide/Tilt/TiltFeedbackView.swift
+++ b/Chalkak/Core/Guide/Tilt/TiltFeedbackView.swift
@@ -40,14 +40,15 @@ struct TiltFeedbackView: View {
     // MARK: - Properties
     // MARK: input properties
     /// X축 기울기 오프셋 값: 기기의 좌우 기울기
-    var offsetX: CGFloat
+    private var offsetX: CGFloat { CGFloat(tiltManager.offsetX) }
     
     /// Y축 기울기 오프셋 값: 기기의 앞뒤 기울기
-    var offsetY: CGFloat
+    private var offsetY: CGFloat { CGFloat(tiltManager.offsetZ) }
     
     // MARK: State properties
     /// 디졸브 애니메이션을 위한 opacity 상태
     @State private var dissolveOpacity: Double = 1.0
+    @ObservedObject var tiltManager: CameraTiltManager
     
     // MARK: computed properties
     /// 자주 사용되는 offset 절대값
@@ -60,16 +61,12 @@ struct TiltFeedbackView: View {
     }
     
     /// 현재 위치가 적절한 범위 내에 있는지 확인하는 계산 프로퍼티
-    var isProperPosition: Bool {
-        if absOffsetX < 3 && absOffsetY < 3 {
-            return true
-        } else {
-            return false
-        }
+    private var isProperPosition: Bool {
+        absOffsetX < 3 && absOffsetY < 3
     }
     
     /// 원의 투명도 결정하는 계산 프로퍼티
-    var circleOpacity: Double {
+    private var circleOpacity: Double {
         // 50 이상이면 안보이게
         if absOffsetX > 50 || absOffsetY > 50 {
             return 0
@@ -83,12 +80,6 @@ struct TiltFeedbackView: View {
         else {
             return 1
         }
-    }
-    
-    // MARK: - init
-    init(offsetX: Float, offsetY: Float) {
-        self.offsetX = CGFloat(offsetX)
-        self.offsetY = CGFloat(offsetY)
     }
     
     // MARK: - View
@@ -124,14 +115,5 @@ struct TiltFeedbackView: View {
                     }
                 }
             }
-    }
-}
-
-#Preview {
-    ZStack {
-        Color.black.opacity(0.7)
-            .ignoresSafeArea()
-        
-        TiltFeedbackView(offsetX: -40, offsetY: -45)
     }
 }

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -105,9 +105,13 @@ class CameraViewModel: ObservableObject {
 
     // MARK: - Camera Set
 
-    func startCamera() { model.startSession() }
+    func startCamera() {
+        tiltCollector.start()
+        model.startSession()
+    }
     func stopCamera() {
         if isRecording { stopVideoRecording() }
+        tiltCollector.stop()
         model.stopSession()
     }
 

--- a/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
@@ -54,7 +54,7 @@ struct GuideCameraView: View {
 
             // Tilt 피드백 뷰
             if let tiltManager = viewModel.tiltManager {
-                TiltFeedbackView(offsetX: tiltManager.offsetX, offsetY: tiltManager.offsetZ)
+                TiltFeedbackView(tiltManager: tiltManager)
             }
         }
         .onAppear {


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- closed: #34

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

추가 촬영 시점에 Tilt Guide가 멈추는 현상을 해결했습니다.

기존 구현 상태에서는 tiltManager.offsetX가 바뀌어도 GuideCameraView 자체가 다시 렌더링되지 않으면
TiltFeedbackView는 다시 호출되지 않는 구조였습니다.
그런데 Camera 화면 전체에서 주기적으로 뭔가 바뀌는 상태가 거의 없었고, 그래서 Tilt 값은 내부에서 계속 바뀌는데
SwiftUI는 화면을 다시 그리지 않고 있어서 Tilt Guide가 멈춘 것 처럼 보이게 되었습니다.

Tilt Guide UI가 변경된 값이 아니라 TiltManager 자체를 관찰하도록 구조를 변경함으로써 문제를 해결했습니다.

추가적으로, CoreMotion 연산이 main에서 이뤄지고 있었는데, 현재 main에서 이뤄지는 연산이 아주 다양하고 많아서
(AVCaptureSession start / stop, Vision bounding box 처리, UI 관련 동작, Navigation push / pop, Timer 등등)
CoreMotion 연산이 지연되는 일이 없도록 하기 위해서 operationQueue를 이용해 CoreMotion 연산을 main 스레드에서 분리했습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.


https://github.com/user-attachments/assets/501acd69-be4a-419e-8187-16bb035578ac


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 녹화 시작시 다시 움직이던 이유
앞서 작업 내용 설명에서 Camera가 뭔가 바뀌는 상태가 없어 UI를 다시 그리지 않고 있던것을 원인으로 설명했습니다.
녹화를 시작하게 되면 바뀌는 상태가 생겨 Tilt Guide를 다시 그리며 움직이게 된 것이었습니다.
하지만 계속해서 Tilt 값 변화에 맞춰 다시 그리는 것 아닌, 잠시 바뀐 상태를 마주해 Tilt Guide가 그려지는 것이었기에
매끄럽지 않고 가이드가 끊기는 듯한 느낌이 지속되고 있었습니다.


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
