### PR TITLE
🐛 [fix] 가이드 선택뷰 타이머가 남은시간 기준으로 나오던 문제 수정

### DIFF
--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
@@ -87,6 +87,7 @@ struct GuideSelectView: View {
                 VideoControlView(
                     isDragging: isDragging,
                     overlayImage: overlayImage,
+                    displayTime: editViewModel.startPoint,
                     editViewModel: editViewModel
                 )
 
@@ -101,6 +102,7 @@ struct GuideSelectView: View {
                             .foregroundStyle(SnappieColor.primaryHeavy)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.leading, 24)
+
 
                         Text((clip.endPoint - clip.startPoint).formattedTime)
                             .font(SnappieFont.style(.roundCaption1))

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -190,6 +190,7 @@ struct ClipEditView: View {
             Analytics.logEvent("retakeButtonTapped", parameters: nil)
         }
         .task {
+            await editViewModel.generateThumbnails()
             // 저장된 트리밍 값 유지
             if shootState != .firstShoot, editViewModel.clipID == nil {
                 editViewModel.applyReferenceDuration()

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -62,7 +62,7 @@ final class ClipEditViewModel: ObservableObject {
     private let thumbnailCount = 10
     
     private var trimOffset: Double = 0
-    
+
     // 5. init & deinit
     init(
         clipURL: URL,
@@ -119,7 +119,6 @@ final class ClipEditViewModel: ObservableObject {
                     self.player = AVPlayer(playerItem: playerItem)
                 }
 
-                await generateThumbnails(for: asset)
                 await updatePreviewImage(at: self.startPoint)
                 playPreview()
 
@@ -131,7 +130,7 @@ final class ClipEditViewModel: ObservableObject {
     
     /// 영상 전체 길이와 썸네일 간격을 계산하여, 일정 시간 간격으로 트리밍 타임라인 썸네일 이미지 생성
     @MainActor
-    private func generateThumbnails(for asset: AVAsset) async {
+    func generateThumbnails() async {
         guard let imageGenerator = imageGenerator else { return }
         thumbnails = []
         let interval = duration / Double(thumbnailCount)

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
@@ -33,6 +33,11 @@ struct VideoControlPanelView: View {
     @ObservedObject var editViewModel: ClipEditViewModel
     @Binding var isOverlayVisible: Bool
     let showOverlayToggle: Bool
+    var displayTime: Double? = nil
+
+    private var timeToDisplay: Double {
+        displayTime ?? editViewModel.currentTrimmedDuration
+    }
 
     var body: some View {
         ZStack(alignment: .center) {
@@ -51,7 +56,7 @@ struct VideoControlPanelView: View {
             HStack(alignment: .center) {
                 Spacer()
 
-                Text(String(format: "%.2f초", self.editViewModel.currentTrimmedDuration))
+                Text(String(format: "%.2f초", timeToDisplay))
                     .font(SnappieFont.style(.proLabel3))
                     .foregroundStyle(SnappieColor.labelDarkNormal)
                     .padding(.horizontal, 9.5)

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
@@ -30,13 +30,14 @@ import AVFoundation
 struct VideoControlView: View {
     let isDragging: Bool
     let overlayImage: UIImage?
+    var displayTime: Double? = nil
 
     @ObservedObject var editViewModel: ClipEditViewModel
     @State private var isOverlayVisible: Bool = true
-    
+
     var body: some View {
         VStack(alignment: .center, spacing: 16 ,content: {
-            
+
             VideoPreviewWithOverlay(
                 previewImage: editViewModel.previewImage,
                 player: editViewModel.player,
@@ -44,11 +45,12 @@ struct VideoControlView: View {
                 overlayImage: overlayImage,
                 isOverlayVisible: $isOverlayVisible
             )
-            
+
             VideoControlPanelView(
                 editViewModel: editViewModel,
                 isOverlayVisible: $isOverlayVisible,
-                showOverlayToggle: overlayImage != nil
+                showOverlayToggle: overlayImage != nil,
+                displayTime: displayTime
             )
         })
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #58 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.
- `generateThumbnails`을 `View`에서 실행하게끔 했습니다. 
- `GuideSelectView`에서는 썸네일을 `trimmedClip`안에서 만들어주고있어서, 가끔가다가 이게 두번실행되어서 썸네일이 20개 생성되는 문제가 있더라구요. 그래서 일단은 `generateThumbnails`을 ViewModel에서 호출하지않고, `ClipEditView`의 task에서 호출하게끔했습니다. 


## 📍 PR Point 
- 결국에는 ClipEditViewModel을 중복사용하는데에서 오는 문제라 이후에 개별적인 뷰모델로 분리를 할 예정입니다. 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
