### PR TITLE
🐛 [Fix] #64 전면 카메라 감지 키값을 cameraPosition 하나로 통일

### DIFF
--- a/Chalkak/Core/Guide/Overlay/OverlayManager.swift
+++ b/Chalkak/Core/Guide/Overlay/OverlayManager.swift
@@ -45,7 +45,13 @@ class OverlayManager: ObservableObject {
         let maskRequest = VNGenerateForegroundInstanceMaskRequest()
         rectangleRequest.upperBodyOnly = true
         let handler = VNImageRequestHandler(ciImage: image, options: [:])
-        let savedIsFront = UserDefaults.standard.bool(forKey: UserDefaultKey.isFrontPosition)
+        
+        let isFront: Bool
+        if let savedValue = UserDefaults.standard.string(forKey: UserDefaultKey.cameraPosition) {
+            isFront = (savedValue == "front")
+        } else {
+            isFront = false
+        }
 
         DispatchQueue.global().async {
             do {
@@ -55,7 +61,7 @@ class OverlayManager: ObservableObject {
                 if let results = rectangleRequest.results, !results.isEmpty {
                     let correctedBoxes = results.map { observation -> CGRect in
                             let box = observation.boundingBox
-                            if savedIsFront {
+                            if isFront {
                                 // 좌우 반전
                                 return CGRect(
                                     x: 1 - box.origin.x - box.size.width,

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -261,14 +261,23 @@ class CameraViewModel: ObservableObject {
         UserDefaults.standard.set(setting.isGridEnabled, forKey: UserDefaultKey.isGridOn)
         UserDefaults.standard.set(setting.zoomScale, forKey: UserDefaultKey.zoomScale)
         UserDefaults.standard.set(setting.timerSecond, forKey: UserDefaultKey.timerSecond)
-        UserDefaults.standard.set(setting.isFrontPosition, forKey: UserDefaultKey.isFrontPosition)
+
+        let positionValue = setting.isFrontPosition ? "front" : "back"
+        UserDefaults.standard.set(positionValue, forKey: UserDefaultKey.cameraPosition)
     }
 
     private func loadSavedSettings() {
         isGrid = UserDefaults.standard.bool(forKey: UserDefaultKey.isGridOn)
         zoomScale = UserDefaults.standard.object(forKey: UserDefaultKey.zoomScale) as? CGFloat ?? 1.0
         selectedTimerDuration = TimerOptions(rawValue: UserDefaults.standard.integer(forKey: UserDefaultKey.timerSecond)) ?? .off
-        cameraPostion = UserDefaults.standard.bool(forKey: UserDefaultKey.isFrontPosition) ? .front : .back
+
+        if let savedValue = UserDefaults.standard.string(forKey: UserDefaultKey.cameraPosition),
+           savedValue == "front"
+        {
+            cameraPostion = .front
+        } else {
+            cameraPostion = .back
+        }
     }
 
     // MARK: - Camera Switching


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #64 

## ✨ PR Content
> 그동안 전면 카메라 감지 키값이 isFrontPosition 과  `cameraPosition`이 동시에 사용됨
- `isFrontPosition` -  CameraViewModel에서 bool 타입
- `cameraPosition` - CameraManager에서  `front` or `back`  String타입

## 📍 PR Point 
- 이런 키값을 세팅하는 하나의 싱글톤 매니저를 만들어서 관리하면 좀 이런 중복이슈가 없었을까? 싶긴한데, 그전에 아무래도 이런 클래스가 어디까지 책임을 갖고있는지가 모호했던 탓에 같은 역할을 하는게 분산되어 있었던 것 같네요..

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
