### PR TITLE
✨ [Feat] 가이드 클립 삭제 시 alert 로직 구현

### DIFF
--- a/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
+++ b/Chalkak/Common/DesignSystem/Alert/CommonAlert.swift
@@ -14,6 +14,7 @@ enum AlertType {
     case finishShooting
     case emptyProjectDelete
     case photoPermissionDenied
+    case cannotDeleteGuideClip
 
     var title: String {
         switch self {
@@ -22,6 +23,8 @@ enum AlertType {
         case .finishShooting: return "촬영을 마치고 나갈까요?"
         case .emptyProjectDelete: return "작업 중인 프로젝트를 삭제할까요?"
         case .photoPermissionDenied: return "사진 라이브러리 접근 권한이 필요해요"
+        case .cannotDeleteGuideClip:
+            return "가이드로 사용된 장면은\n삭제할 수 없어요."
         }
     }
 
@@ -32,13 +35,15 @@ enum AlertType {
         case .finishShooting: return "지금까지 찍은 장면은 저장돼요."
         case .emptyProjectDelete: return "남아있는 장면이 없으면 프로젝트가 삭제돼요."
         case .photoPermissionDenied: return "영상을 저장하려면 사진 라이브러리 접근 권한이 필요해요.\n설정에서 권한을 허용해주세요."
+        case .cannotDeleteGuideClip:
+            return "다른 장면을 가이드로 지정한 후 장면을 삭제할 수 있어요."
         }
     }
 
     var confirmText: String {
         switch self {
         case .deleteProject: return "삭제"
-        case .retakeVideo: return "확인"
+        case .retakeVideo, .cannotDeleteGuideClip: return "확인"
         case .finishShooting: return "나가기"
         case .emptyProjectDelete: return "삭제"
         case .photoPermissionDenied: return "설정으로 이동"

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -221,18 +221,41 @@ struct ProjectEditView: View {
         .sheet(isPresented: $showExportView) {
             ProjectPreviewView(editableClips: viewModel.editableClips)
         }
-
+        
+        // 가이드 클립 삭제 시, 불가능 알림
+        .alert(
+            AlertType.cannotDeleteGuideClip.title,
+            isPresented: $viewModel.showCannotDeletGuideClipAlert,
+            actions: {
+                Button("확인") {
+                    print("삭제 못하고 확인버튼을 누르기")
+                }
+            },
+            message: {
+                Text(AlertType.cannotDeleteGuideClip.message)
+            }
+        )
+        
         // 모든 클립 삭제 시, 프로젝트 삭제 알림
         .alert(
-            .emptyProjectDelete,
+            AlertType.emptyProjectDelete.title,
             isPresented: $viewModel.showEmptyProjectAlert,
-            confirmAction: {
-                Task {
-                    let success = await viewModel.deleteEmptyProject()
-                    if success {
-                        coordinator.popToScreen(.projectList)
+            actions: {
+                Button(AlertType.emptyProjectDelete.confirmText, role: .destructive) {
+                    Task {
+                        let success = await viewModel.deleteEmptyProject()
+                        if success {
+                            coordinator.popToScreen(.projectList)
+                        }
                     }
                 }
+                
+                Button("취소", role: .cancel) {
+                    print("삭제 취소")
+                }
+            },
+            message: {
+                Text(AlertType.emptyProjectDelete.message)
             }
         )
 

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -30,6 +30,7 @@ final class ProjectEditViewModel {
   
     var isLoading = false
     var showEmptyProjectAlert = false
+    var showCannotDeletGuideClipAlert = false
     var selectedClipID: String?
 
     // 변경사항을 추적하기위한 originalClip - 상태 저장용 프로퍼티
@@ -666,6 +667,11 @@ final class ProjectEditViewModel {
                 showEmptyProjectAlert = true
                 return // 여기서 완전히 종료, 아무것도 삭제하지 않음
             }
+        }
+        // 가이드 클립인지 확인 - 삭제 불가능 alert
+        if tempProject.guide.clipID == id {
+            showCannotDeletGuideClipAlert = true
+            return // 삭제하지 않고 실행 종료
         }
         let currentTime = playHead
 


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Closes: #61

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

다른 클립이 있는 상황에서 가이드 클립 삭제 불가능 안내와 확인 버튼이 있는 alert을,
가이드 클립만 남았을 경우 프로젝트 삭제됨 경고 alert을 보이도록 구현하였습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- extension으로 자체 구현해둔 alert이 뜨지 않아서 임시로 시스템 alert 컴포넌트를 활용해 구현하였습니다. .alert의 리턴 타입과 자체 리턴 타입의 차이가 있는 것인지 확인이 필요한 상황입니다!
- alert이 안떠서 이런저런 런타임에러가 났던 상황이 있었어서요(alert 로직 잘 연결된 후에는 정상작동 일단 확인했습니다), 번거로우시겠지만 시간이 허락하신다면 브랜치에서 잘 돌아가는지 다른 휴대폰으로도 확인해주시면 감사드리겠습니다 🙏


## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
