### PR TITLE
✨ [feat] #77 isDirty 플래그 기반 변경 감지 로직 구현

### DIFF
--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -44,7 +44,7 @@ struct ProjectEditView: View {
                     }
                 },
                 rightButtonType: .twoButton(
-                    primary: .init(label: "저장") {
+                    primary: .init(label: "저장", isEnabled: viewModel.hasChanges) {
                         Task {
                             isSaving = true
                             let success = await viewModel.commitChanges()

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -34,7 +34,7 @@ final class ProjectEditViewModel {
     var selectedClipID: String?
 
     /// 수정 여부 판단 플래그
-    private(set) var isDirty = false
+    private(set) var hasUnsavedChanges = false
 
     var totalDuration: Double {
         editableClips.reduce(0) { $0 + $1.trimmedDuration }
@@ -47,7 +47,7 @@ final class ProjectEditViewModel {
     // MARK: - Temp 관련 프로퍼티
 
     var hasChanges: Bool {
-        return isDirty
+        return hasUnsavedChanges
     }
 
     var originalProjectID: String {
@@ -78,19 +78,19 @@ final class ProjectEditViewModel {
         // projectEditView뿐만아니라, 클립 편집 / 가이드 같이 다른 뷰로 이탈해서 변경하고 돌아오는 것 감지
         if isAlreadyInitialized, !prevClips.isEmpty {
             if prevClips.count != editableClips.count {
-                isDirty = true
+                hasUnsavedChanges = true
             } else {
                 for (prev, curr) in zip(prevClips, editableClips) {
                     if prev.id == curr.id,
                        prev.startPoint != curr.startPoint || prev.endPoint != curr.endPoint
                     {
-                        isDirty = true
+                        hasUnsavedChanges = true
                         break
                     }
                 }
             }
             if guide?.selectedTimestamp != prevGuideTimestamp {
-                isDirty = true
+                hasUnsavedChanges = true
             }
         }
     }
@@ -502,7 +502,7 @@ final class ProjectEditViewModel {
 
     func moveClip(from source: IndexSet, to destination: Int) {
         let currentTime = playHead
-        isDirty = true
+        hasUnsavedChanges = true
 
         // 1. Reorder the UI-facing array
         editableClips.move(fromOffsets: source, toOffset: destination)
@@ -625,7 +625,7 @@ final class ProjectEditViewModel {
         }
 
         // 처음 생성시 false
-        isDirty = false
+        hasUnsavedChanges = false
 
         // Context에 추가 (Guide와 CameraSetting 먼저)
         SwiftDataManager.shared.context.insert(tempGuide)
@@ -652,7 +652,7 @@ final class ProjectEditViewModel {
             print("현재 temp 프로젝트가 아닙니다.")
             return
         }
-        isDirty = true
+        hasUnsavedChanges = true
 
         let nextOrder = (tempProject.clipList.map(\.order).max() ?? -1) + 1
 
@@ -695,7 +695,7 @@ final class ProjectEditViewModel {
             return // 삭제하지 않고 실행 종료
         }
         let currentTime = playHead
-        isDirty = true
+        hasUnsavedChanges = true
 
         // 1. 플레이어 정리 (삭제될 클립 참조 방지)
         player.pause()
@@ -740,7 +740,7 @@ final class ProjectEditViewModel {
         guard let idx = editableClips.firstIndex(where: { $0.id == clipID }) else { return }
         editableClips[idx].startPoint = max(0, min(start, editableClips[idx].originalDuration))
         editableClips[idx].endPoint = max(0, min(end, editableClips[idx].originalDuration))
-        isDirty = true
+        hasUnsavedChanges = true
 
         // 드래그 중이 아닐 때 플레이어 업데이트 수행
         if !isDragging {


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #77 , #81

## ✨ PR Content
- 기존 코드는 항상 변경사항으로 간주하게끔 구현되어있었습니다! 
```swift
var hasChanges: Bool {
    guard let project = SwiftDataManager.shared.fetchProject(byID: projectID)
    else { return false }
    return project.isTemp  //  temp이기만 하면 무조건 true인데, 항상 isTemp는 변경하러들어왔으니 true
}
```
때문에 변경사항에 관계없이 Alert가 계속 등장했던 것이었는데, 이를 해결하기위해서
-  `snapShot`을 만들어서 일일히 클립의 길이, 시작,끝 지점, 가이드 상태, 등등을 따로 구조체로 만들어서 `Equatable`로 감지를 해주려했는데, 코드가 번잡해지기도하고, 간헐적으로 크래시가 발생한탓에 더 쉬운 방법으로 하고자했습니다! 

그래서 결국 좀 원시적일 수 있는데, `isDirty`플래그를 추가해서 진짜 변경을 시키는 함수에다가 isDirty가 true로 변경되게 해서 감지해줬습니다. 


### #81 버그 관련

`deleteClip`함수에서 
`tempProject.clipList.removeAll { $0.id == id }`

이렇게 배열에서만 제거해주고 있었는데, 이러면 SwiftData context에는 해당 클립 객체가 그대로 남아있어서 cascade delete가 먹지 않는 문제가 있었습니다
그래서 temp클립을 일단 삭제는했는데, <저장하지 않고 나가기> 하면 discardChanges()에서 teemp 프로젝트만 삭제가 되는데, 배열에서 빠진 클립은 cascade로도 안지워져서 연결은 끊긴채로 남았던 겁니다! (고아 상태라고 하더라구요!) 
그래서 상태에서 다시 진입하면 initializeTempProject()가 호출되면서 새로운 temp 클립을 만들려 하는데, 이전에 제대로 삭제 안 된 클립과 동일한 ID로 생성하려하니까 충돌이 나서 터지는 거였어요!

이게 원본 아이디를 기반으로 만들어지다보니까 중복으로 발생하는게 생겨서 생긴 문제였습니닷..! 사실 그냥 매번 다르게 uuid같이 만들어주고 있었다면 오히려 에러가 안뜰 수 있었긴하겠네요..! 

### `initializeTempProject`
```swift
// Guide 복사본 생성 (원본과 완전히 분리)
let tempGuide = Guide(
  clipID: "temp_\(originalProject.guide.clipID)",  // <- 중복의 원흉
```

## 📍 PR Point  
- `loadProject`가 좀 많이 변경된 것은 클립을 눌러서 가이드나, 길이를 변경하고 돌아왔을때 다시 `load`해주는 시점에서 감지하게끔 해주려고 했습니다 ! 
- 다음에 `uuid`로 바꾸는것도 고려해볼만 하겠네요 !! 
