### PR TITLE
✨ [feat] #82 프리셋버튼으로 줌배율 조정시 차츰차츰 전환되게끔 개선

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -55,6 +55,7 @@ class CameraManager: NSObject, ObservableObject {
             UserDefaults.standard.set(value, forKey: UserDefaultKey.cameraPosition)
         }
     }
+
     @Published private(set) var isPreviewMirrored: Bool = false
 
     var onPreviewMirroringChanged: ((Bool) -> Void)?
@@ -170,9 +171,11 @@ class CameraManager: NSObject, ObservableObject {
             device.exposureMode = .continuousAutoExposure
         }
 
-        // 줌 설정 후면 카메라 한정
+        // 줌 설정 (후면 카메라 한정)
         if device.position == .back {
-            applyZoomScale(backCameraZoomScale, to: device)
+            let minZoom = device.minAvailableVideoZoomFactor
+            let maxZoom = device.maxAvailableVideoZoomFactor
+            device.videoZoomFactor = max(minZoom, min(backCameraZoomScale * 2.0, maxZoom))
 
             DispatchQueue.main.async { [weak self] in
                 self?.currentZoomScale = self?.backCameraZoomScale ?? 1.0
@@ -364,40 +367,38 @@ class CameraManager: NSObject, ObservableObject {
         }
     }
 
+    /// 줌 배율 스무스하게 전환 (프리셋 버튼용 0.5,1,2)
+    func smoothSetZoomScale(_ scale: CGFloat) {
+        setZoomScale(scale, rate: 8.0)
+    }
+
     /// 줌 배율 설정
-    func setZoomScale(_ scale: CGFloat) {
+    /// - Parameters:
+    ///   - scale: UI 줌 배율 (0.5 ~ 6.0)
+    ///   - rate: ramp 속도로 조정을 해주는데, 일관성을 위해 즉시반영(슬라이더/핀치 할때만)은. nil로 처리를 해줬고, 값이 있으면 스무스하게 전환되는 것을 의도했습니다.(프리셋버튼 0.5,1,2) rate는 높을수록 반응이 빠름
+    func setZoomScale(_ scale: CGFloat, rate: Float? = nil) {
         guard let device = videoDeviceInput?.device else { return }
         guard device.position == .back else { return }
+
+        let minZoom = device.minAvailableVideoZoomFactor
+        let maxZoom = device.maxAvailableVideoZoomFactor
+        let targetZoom = max(minZoom, min(scale * 2.0, maxZoom))
 
         do {
             try device.lockForConfiguration()
             defer { device.unlockForConfiguration() }
 
-            applyZoomScale(scale, to: device)
-
-            currentZoomScale = scale
-            backCameraZoomScale = scale
-
+            if let rate {
+                device.ramp(toVideoZoomFactor: targetZoom, withRate: rate)
+            } else {
+                device.videoZoomFactor = targetZoom
+            }
         } catch {
             print("줌 조정 에러 \(error)")
         }
-    }
 
-    /// 디바이스에 실제 줌 배율을 적용
-    /// - Parameters:
-    ///   - scale: UI 줌 배율
-    ///   - device: AVCaptureDevice
-    /// - Note: device.lockForConfiguration() 이미 호출된 상태에서만 활용할 수 있음!  줌 설정이 끝나면  lockForConfiguration역시 필요 합니다 !
-    private func applyZoomScale(_ scale: CGFloat, to device: AVCaptureDevice) {
-        let minZoom = device.minAvailableVideoZoomFactor
-        let maxZoom = device.maxAvailableVideoZoomFactor
-
-        // UI 스케일을 실제 줌 배율 변환
-        let zoomAdjustment = scale * 2.0
-
-        let clampedZoomFactor = max(minZoom, min(zoomAdjustment, maxZoom))
-
-        device.videoZoomFactor = clampedZoomFactor
+        currentZoomScale = scale
+        backCameraZoomScale = scale
     }
 
     /// 카메라 세션 시작
@@ -488,7 +489,7 @@ private extension CameraManager {
         guard let connection = connection else { return }
         let mirrored = connection.isVideoMirrored
 
-        if self.isPreviewMirrored != mirrored {
+        if isPreviewMirrored != mirrored {
             DispatchQueue.main.async {
                 self.isPreviewMirrored = mirrored
                 self.onPreviewMirroringChanged?(mirrored)
@@ -501,7 +502,7 @@ private extension CameraManager {
     func refreshPreviewMirroring() {
         propagatePreviewMirroring(from: previewLayer?.connection)
     }
-    
+
     func updateRecordingMirroring() {
         // movieOutput
         if let conn = movieOutput.connection(with: .video), conn.isVideoMirroringSupported {
@@ -531,13 +532,12 @@ private extension CameraManager {
             conn.automaticallyAdjustsVideoMirroring = false
         }
     }
-
 }
 
 extension CameraManager {
     enum RecordingMirrorPolicy {
-        case followPreview   // 권장: 프리뷰가 미러면 파일도 미러
-        case alwaysMirrored  // 항상 미러 저장
-        case neverMirrored   // 절대 미러 저장 X (기존 방식)
+        case followPreview // 권장: 프리뷰가 미러면 파일도 미러
+        case alwaysMirrored // 항상 미러 저장
+        case neverMirrored // 절대 미러 저장 X (기존 방식)
     }
 }

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -109,6 +109,7 @@ class CameraViewModel: ObservableObject {
         tiltCollector.start()
         model.startSession()
     }
+
     func stopCamera() {
         if isRecording { stopVideoRecording() }
         tiltCollector.stop()
@@ -151,13 +152,22 @@ class CameraViewModel: ObservableObject {
         }
     }
 
-    func selectZoomScale(_ scale: CGFloat) {
+    /// 줌 배율 설정
+    /// - Parameters:
+    ///   - scale: 줌 배율 (0.5 ~ 6.0)
+    ///   - smooth: true - (프리셋 버튼), false - (슬라이더/핀치)
+    func selectZoomScale(_ scale: CGFloat, smooth: Bool = false) {
         guard !isUsingFrontCamera else { return }
         guard !scale.isNaN, !scale.isInfinite else { return }
 
         let safeScale = max(minZoomScale, min(maxZoomScale, scale))
         zoomScale = safeScale
-        model.setZoomScale(safeScale)
+
+        if smooth {
+            model.smoothSetZoomScale(safeScale)
+        } else {
+            model.setZoomScale(safeScale)
+        }
 
         lastZoomInteraction = Date()
         if showingZoomControl { startZoomSliderAutoHideTimer() }

--- a/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
@@ -64,7 +64,7 @@ struct CameraZoomControlView: View {
               !range.isActive(viewModel.zoomScale) else { return }
 
         withAnimation(.easeInOut(duration: Layout.animationDuration)) {
-            viewModel.selectZoomScale(range.preset)
+            viewModel.selectZoomScale(range.preset, smooth: true)
         }
     }
 


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #82 

## 변경 내용

- 기존의 프리셋버튼을 눌러서 줌을 조정할때 점프 하는식으로 바뀌는 것이 거슬린다는 요청이 들어와서, 이를 어떻게 자연스럽게 개선할지를 찾아봤는데, [ramp](https://developer.apple.com/documentation/avfoundation/avcapturedevice/ramp(tovideozoomfactor:withrate:))라고 공식적으로 지원하는 api가 있더라구요.

- 그래서 이를 활용하는데, ramp에는 보시다시피 `withRate`를 인자값으로 넣어줘야하는데, 이거는 얼마나 딜레이걸려서 해당 줌으로 조정을 해줄지에 대한 요소라서 
```
Transition rate to new magnification factor is specified in powers of two per second.
```
rate는 8.0을 줬는데 0.125초마다 줌이 2배씩 커지는 속도라고 생각하면 됩니다! 

근데 그렇게해서 스무스하게 변경되는 함수를 만들어서 적용하니
1. 기존 프리셋버튼
2. 핀치/슬라이더
두가지 동일한 행동에 대해서 다른함수가 있는게 너무 가독성도 떨어지고 별로인것같아서, 
기존에 있던 setZoomScale을 rate가 nil인형태로하고, 프리셋버튼에대해서는 rate를 적용한 것으로 분리해줬습니다! 


- smooth: true → 프리셋 버튼 (스무스하게 전환)
- smooth: false (기본값) → 슬라이더/핀치 (즉시 반영)


## 📸 Screenshot
https://github.com/user-attachments/assets/e9058742-9209-4936-a090-59e17f17e483
