### PR TITLE
🐛 [Fix] 클립 편집 시점 - 우측 핸들 비활성화 처리

### DIFF
--- a/Chalkak/Presentation/ClipEdit/SubViews/TrimmingLineView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/TrimmingLineView.swift
@@ -80,7 +80,7 @@ struct TrimmingLineView: View {
                 topTrailingRadius: 6
             )
             .fill(SnappieColor.darkHeavy.opacity(0.6))
-            .frame(width: max(0, thumbnailLineWidth + handleWidth - endX), height: thumbnailHeight)
+            .frame(width: max(0, thumbnailLineWidth + handleWidth), height: thumbnailHeight)
             .offset(x: endX)
 
             // 4. 트리밍 박스


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #85

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

- 비활성화 표시가 안되던 우측핸들 UI 인터랙션 수정

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

- 수정 완료된 이미지
<img width="529" height="271" alt="Screenshot 2026-02-23 at 1 29 44 AM" src="https://github.com/user-attachments/assets/d6671213-e3b3-44b1-ab6c-693dfb5ec290" />

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

x

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
