### PR TITLE
♻️ [refactor] #29 ClipEditViewModel 역할 분리 및 의존성 개선

### DIFF
--- a/Chalkak.xcodeproj/project.pbxproj
+++ b/Chalkak.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7D3DFFD42EFD5E9C00E15204 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3DFFD32EFD5E9C00E15204 /* PermissionManager.swift */; };
 		7D3DFFD82EFD604600E15204 /* PermissionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3DFFD72EFD604200E15204 /* PermissionState.swift */; };
 		7D60F6492F0D141800621874 /* SchemaV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D60F6482F0D141700621874 /* SchemaV3.swift */; };
+		7DD5117A2F5FF740005A4701 /* GuideSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD511792F5FF740005A4701 /* GuideSelectViewModel.swift */; };
 		7DD82CBB2EFEA2E400AD8DFC /* GuideSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD82CBA2EFEA2E400AD8DFC /* GuideSelectView.swift */; };
 		7DD82CC02EFEC2A400AD8DFC /* GuideFrameSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD82CBF2EFEC29B00AD8DFC /* GuideFrameSelectorView.swift */; };
 		7DD82CC32EFECCA000AD8DFC /* TimeLineConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD82CC22EFECC9A00AD8DFC /* TimeLineConstants.swift */; };
@@ -179,6 +180,7 @@
 		7D3DFFD32EFD5E9C00E15204 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		7D3DFFD72EFD604200E15204 /* PermissionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionState.swift; sourceTree = "<group>"; };
 		7D60F6482F0D141700621874 /* SchemaV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV3.swift; sourceTree = "<group>"; };
+		7DD511792F5FF740005A4701 /* GuideSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideSelectViewModel.swift; sourceTree = "<group>"; };
 		7DD82CBA2EFEA2E400AD8DFC /* GuideSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideSelectView.swift; sourceTree = "<group>"; };
 		7DD82CBF2EFEC29B00AD8DFC /* GuideFrameSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideFrameSelectorView.swift; sourceTree = "<group>"; };
 		7DD82CC22EFECC9A00AD8DFC /* TimeLineConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeLineConstants.swift; sourceTree = "<group>"; };
@@ -381,6 +383,7 @@
 		7DD82CBC2EFEC26600AD8DFC /* GuideSelect */ = {
 			isa = PBXGroup;
 			children = (
+				7DD511792F5FF740005A4701 /* GuideSelectViewModel.swift */,
 				7DD82CBF2EFEC29B00AD8DFC /* GuideFrameSelectorView.swift */,
 				7DD82CBA2EFEA2E400AD8DFC /* GuideSelectView.swift */,
 			);
@@ -1182,6 +1185,7 @@
 				C5886D3B2E375B46000566C5 /* ProjectCardCoverImageView.swift in Sources */,
 				C5FB3EBF2E277CAA00A4C1BE /* VideoLoader.swift in Sources */,
 				9340078D2E340459006BE89C /* VideoControlPanelView.swift in Sources */,
+				7DD5117A2F5FF740005A4701 /* GuideSelectViewModel.swift in Sources */,
 				C5886D3D2E376A4D000566C5 /* ProjectInfoMenuView.swift in Sources */,
 				993A1F6B2E267E0C0059B70A /* CircleIconButton.swift in Sources */,
 				C5C12EA22E2FEE1C00C4DC6D /* SnappieButton.swift in Sources */,

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideFrameSelectorView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideFrameSelectorView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct GuideFrameSelectorView: View {
-    var editViewModel: ClipEditViewModel
+    var viewModel: GuideSelectViewModel
     @Binding var isDragging: Bool
 
     var body: some View {
@@ -17,19 +17,19 @@ struct GuideFrameSelectorView: View {
         let handleWidth: CGFloat = TimelineConstants.handleWidth
         let thumbnailHeight: CGFloat = TimelineConstants.thumbnailHeight
 
-        let thumbnailUnitWidth = editViewModel.thumbnailUnitWidth(for: thumbnailLineWidth)
+        let thumbnailUnitWidth = viewModel.thumbnailUnitWidth(for: thumbnailLineWidth)
         // 박스가 오른쪽 핸들 넘지 않게 제한
-        let rawFrameX = editViewModel.startX(thumbnailLineWidth: thumbnailLineWidth, handleWidth: handleWidth)
+        let rawFrameX = viewModel.startX(thumbnailLineWidth: thumbnailLineWidth, handleWidth: handleWidth)
         let maxFrameX = handleWidth + thumbnailLineWidth - TimelineConstants.frameBoxWidth
         let frameX = max(handleWidth, min(rawFrameX, maxFrameX))
-        let duration = editViewModel.duration
+        let duration = viewModel.duration
 
         ZStack(alignment: .leading) {
             HStack(spacing: 0) {
                 HandleCapsule(isLeading: true)
 
                 HStack(spacing: 0) {
-                    ForEach(Array(editViewModel.thumbnails.enumerated()), id: \.offset) { _, image in
+                    ForEach(Array(viewModel.thumbnails.enumerated()), id: \.offset) { _, image in
                         Image(uiImage: image)
                             .resizable()
                             .scaledToFill()
@@ -73,8 +73,8 @@ struct GuideFrameSelectorView: View {
             DragGesture(minimumDistance: 0)
                 .onChanged { gesture in
                     isDragging = true
-                    editViewModel.player.pause()
-                    editViewModel.isPlaying = false
+                    viewModel.player.pause()
+                    viewModel.isPlaying = false
 
                     let draggedFrameX = gesture.location.x
                     let minFrameX = handleWidth
@@ -84,11 +84,11 @@ struct GuideFrameSelectorView: View {
                     let ratio = (clampedFrameX - handleWidth) / (thumbnailLineWidth - TimelineConstants.frameBoxWidth)
                     let newStart = ratio * duration
 
-                    editViewModel.updateStart(newStart)
+                    viewModel.updateStart(newStart)
                 }
                 .onEnded { _ in
                     isDragging = false
-                    editViewModel.seek(to: editViewModel.startPoint)
+                    viewModel.seek(to: viewModel.startPoint)
                 }
         )
     }

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideFrameSelectorView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideFrameSelectorView.swift
@@ -7,8 +7,24 @@
 
 import SwiftUI
 
+struct FrameSelectorState {
+    let thumbnails: [UIImage]
+    let duration: Double
+    let startPoint: Double
+    let thumbnailUnitWidth: (CGFloat) -> CGFloat
+    let startX: (CGFloat, CGFloat) -> CGFloat
+}
+
+struct FrameSelectorActions {
+    let pause: () -> Void
+    let setNotPlaying: () -> Void
+    let updateStart: (Double) -> Void
+    let seek: (Double) -> Void
+}
+
 struct GuideFrameSelectorView: View {
-    var viewModel: GuideSelectViewModel
+    let state: FrameSelectorState
+    let actions: FrameSelectorActions
     @Binding var isDragging: Bool
 
     var body: some View {
@@ -17,19 +33,19 @@ struct GuideFrameSelectorView: View {
         let handleWidth: CGFloat = TimelineConstants.handleWidth
         let thumbnailHeight: CGFloat = TimelineConstants.thumbnailHeight
 
-        let thumbnailUnitWidth = viewModel.thumbnailUnitWidth(for: thumbnailLineWidth)
+        let thumbnailUnitWidth = state.thumbnailUnitWidth(thumbnailLineWidth)
         // 박스가 오른쪽 핸들 넘지 않게 제한
-        let rawFrameX = viewModel.startX(thumbnailLineWidth: thumbnailLineWidth, handleWidth: handleWidth)
+        let rawFrameX = state.startX(thumbnailLineWidth, handleWidth)
         let maxFrameX = handleWidth + thumbnailLineWidth - TimelineConstants.frameBoxWidth
         let frameX = max(handleWidth, min(rawFrameX, maxFrameX))
-        let duration = viewModel.duration
+        let duration = state.duration
 
         ZStack(alignment: .leading) {
             HStack(spacing: 0) {
                 HandleCapsule(isLeading: true)
 
                 HStack(spacing: 0) {
-                    ForEach(Array(viewModel.thumbnails.enumerated()), id: \.offset) { _, image in
+                    ForEach(Array(state.thumbnails.enumerated()), id: \.offset) { _, image in
                         Image(uiImage: image)
                             .resizable()
                             .scaledToFill()
@@ -73,8 +89,8 @@ struct GuideFrameSelectorView: View {
             DragGesture(minimumDistance: 0)
                 .onChanged { gesture in
                     isDragging = true
-                    viewModel.player.pause()
-                    viewModel.isPlaying = false
+                    actions.pause()
+                    actions.setNotPlaying()
 
                     let draggedFrameX = gesture.location.x
                     let minFrameX = handleWidth
@@ -84,11 +100,11 @@ struct GuideFrameSelectorView: View {
                     let ratio = (clampedFrameX - handleWidth) / (thumbnailLineWidth - TimelineConstants.frameBoxWidth)
                     let newStart = ratio * duration
 
-                    viewModel.updateStart(newStart)
+                    actions.updateStart(newStart)
                 }
                 .onEnded { _ in
                     isDragging = false
-                    viewModel.seek(to: viewModel.startPoint)
+                    actions.seek(state.startPoint)
                 }
         )
     }

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideFrameSelectorView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideFrameSelectorView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct GuideFrameSelectorView: View {
-    @ObservedObject var editViewModel: ClipEditViewModel
+    var editViewModel: ClipEditViewModel
     @Binding var isDragging: Bool
 
     var body: some View {

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
@@ -19,7 +19,7 @@ struct GuideSelectView: View {
     let cameraSetting: CameraSetting
     let cameraManager: CameraManager
 
-    @State private var editViewModel: ClipEditViewModel
+    @State private var viewModel: GuideSelectViewModel
     @EnvironmentObject private var coordinator: Coordinator
     @State private var isDragging = false
 
@@ -44,12 +44,7 @@ struct GuideSelectView: View {
         self.cameraSetting = cameraSetting
         self.cameraManager = cameraManager
 
-        // ClipEditViewModel 재사용 (트리밍 기능은 사용하지 않음)
-        _editViewModel = State(wrappedValue: ClipEditViewModel(
-            clipURL: clip.videoURL,
-            cameraSetting: cameraSetting,
-            timeStampedTiltList: []
-        ))
+        _viewModel = State(wrappedValue: GuideSelectViewModel(clipURL: clip.videoURL))
     }
 
     var body: some View {
@@ -70,7 +65,7 @@ struct GuideSelectView: View {
                             }
 
                             // 트리밍 시간을 원본시간으로 변환
-                            let originalTimestamp = clip.startPoint + editViewModel.startPoint
+                            let originalTimestamp = clip.startPoint + viewModel.startPoint
 
                             coordinator.push(
                                 .overlay(
@@ -87,8 +82,13 @@ struct GuideSelectView: View {
                 VideoControlView(
                     isDragging: isDragging,
                     overlayImage: overlayImage,
-                    displayTime: editViewModel.startPoint,
-                    editViewModel: editViewModel
+                    displayTime: viewModel.startPoint,
+                    previewImage: viewModel.previewImage,
+                    player: viewModel.player,
+                    isPlayerReady: viewModel.isPlayerReady,
+                    isRebuildingPlayer: viewModel.isRebuildingPlayer,
+                    isPlaying: viewModel.isPlaying,
+                    onTogglePlayback: { viewModel.togglePlayback() }
                 )
 
                 // 클립 시간 표시
@@ -111,7 +111,7 @@ struct GuideSelectView: View {
                             .padding(.trailing, 24)
                     }
                     // 하단 썸네일 부분
-                    GuideFrameSelectorView(editViewModel: editViewModel, isDragging: $isDragging)
+                    GuideFrameSelectorView(viewModel: viewModel, isDragging: $isDragging)
                         .padding(.horizontal, 26)
                 }
             }
@@ -120,22 +120,22 @@ struct GuideSelectView: View {
         .navigationBarBackButtonHidden(true)
         .task {
             // 트리밍된 구간만 보여주도록 설정
-            await editViewModel.trimmedClip(
+            await viewModel.trimmedClip(
                 trimStart: clip.startPoint,
                 trimEnd: clip.endPoint
             )
             // 저장된 가이드 타임스탬프가 있으면 초기 프레임 위치로 반영
             if case .followUpShoot(let guide) = shootState {
                 if let selectedTimestamp = guide.selectedTimestamp {
-                    let clamped = max(0, min(selectedTimestamp - clip.startPoint, editViewModel.duration))
-                    editViewModel.updateStart(clamped)
-                    editViewModel.seek(to: clamped)
+                    let clamped = max(0, min(selectedTimestamp - clip.startPoint, viewModel.duration))
+                    viewModel.updateStart(clamped)
+                    viewModel.seek(to: clamped)
                 }
             } else if case .appendShoot(let guide) = shootState {
                 if let selectedTimestamp = guide.selectedTimestamp {
-                    let clamped = max(0, min(selectedTimestamp - clip.startPoint, editViewModel.duration))
-                    editViewModel.updateStart(clamped)
-                    editViewModel.seek(to: clamped)
+                    let clamped = max(0, min(selectedTimestamp - clip.startPoint, viewModel.duration))
+                    viewModel.updateStart(clamped)
+                    viewModel.seek(to: clamped)
                 }
             }
         }

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
@@ -83,12 +83,15 @@ struct GuideSelectView: View {
                     isDragging: isDragging,
                     overlayImage: overlayImage,
                     displayTime: viewModel.startPoint,
-                    previewImage: viewModel.previewImage,
-                    player: viewModel.player,
-                    isPlayerReady: viewModel.isPlayerReady,
-                    isRebuildingPlayer: viewModel.isRebuildingPlayer,
-                    isPlaying: viewModel.isPlaying,
-                    onTogglePlayback: { viewModel.togglePlayback() }
+                    context: VideoContext(
+                        previewImage: viewModel.previewImage,
+                        player: viewModel.player,
+                        isPlayerReady: viewModel.isPlayerReady,
+                        isRebuildingPlayer: viewModel.isRebuildingPlayer,
+                        isPlaying: viewModel.isPlaying,
+                        currentTrimmedDuration: 0,
+                        onTogglePlayback: { viewModel.togglePlayback() }
+                    )
                 )
 
                 // 클립 시간 표시
@@ -111,7 +114,22 @@ struct GuideSelectView: View {
                             .padding(.trailing, 24)
                     }
                     // 하단 썸네일 부분
-                    GuideFrameSelectorView(viewModel: viewModel, isDragging: $isDragging)
+                    GuideFrameSelectorView(
+                        state: FrameSelectorState(
+                            thumbnails: viewModel.thumbnails,
+                            duration: viewModel.duration,
+                            startPoint: viewModel.startPoint,
+                            thumbnailUnitWidth: { viewModel.thumbnailUnitWidth(for: $0) },
+                            startX: { viewModel.startX(thumbnailLineWidth: $0, handleWidth: $1) }
+                        ),
+                        actions: FrameSelectorActions(
+                            pause: { viewModel.player.pause() },
+                            setNotPlaying: { viewModel.isPlaying = false },
+                            updateStart: { viewModel.updateStart($0) },
+                            seek: { viewModel.seek(to: $0) }
+                        ),
+                        isDragging: $isDragging
+                    )
                         .padding(.horizontal, 26)
                 }
             }

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
@@ -19,7 +19,7 @@ struct GuideSelectView: View {
     let cameraSetting: CameraSetting
     let cameraManager: CameraManager
 
-    @StateObject private var editViewModel: ClipEditViewModel
+    @State private var editViewModel: ClipEditViewModel
     @EnvironmentObject private var coordinator: Coordinator
     @State private var isDragging = false
 
@@ -45,7 +45,7 @@ struct GuideSelectView: View {
         self.cameraManager = cameraManager
 
         // ClipEditViewModel 재사용 (트리밍 기능은 사용하지 않음)
-        _editViewModel = StateObject(wrappedValue: ClipEditViewModel(
+        _editViewModel = State(wrappedValue: ClipEditViewModel(
             clipURL: clip.videoURL,
             cameraSetting: cameraSetting,
             timeStampedTiltList: []

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectViewModel.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectViewModel.swift
@@ -1,0 +1,244 @@
+//
+//  GuideSelectViewModel.swift
+//  Chalkak
+//
+//  Created by bishoe01 on 3/10/26.
+//
+
+import AVFoundation
+import Foundation
+import UIKit
+
+/**
+ GuideSelectViewModel: 가이드 프레임 선택 뷰모델
+
+ GuideSelectView에서 사용하는 ViewModel로, 트리밍된 클립 구간 내에서
+ 가이드 프레임 위치(startPoint)를 탐색하는 기능을 담당합니다.
+
+ ## 주요 기능
+ - AVPlayer 초기화 및 트리밍 구간 설정 (trimmedClip)
+ - 썸네일 생성 (트리밍 구간 기준)
+ - startPoint 업데이트 및 seek
+ - 재생/일시정지 토글
+
+ ## ClipEditViewModel과의 차이
+ - endPoint, 트리밍 핸들, playHead 관련 기능 없음
+ - 저장/프로젝트 관련 기능 없음
+ */
+@MainActor
+@Observable
+final class GuideSelectViewModel {
+    var clipURL: URL
+
+    var player: AVPlayer = .init()
+    var startPoint: Double = 0
+    var duration: Double = 0
+    var thumbnails: [UIImage] = []
+    var isPlaying = false
+    var previewImage: UIImage?
+    var isPlayerReady: Bool = false
+    var isRebuildingPlayer: Bool = false
+
+    private var asset: AVAsset?
+    private var imageGenerator: AVAssetImageGenerator?
+    private var timeObserverToken: Any?
+    private var trimOffset: Double = 0
+    private var currentPlayTime: Double = 0
+    private let thumbnailCount = 10
+
+    init(clipURL: URL) {
+        self.clipURL = clipURL
+        setupPlayer()
+    }
+
+    private func setupPlayer() {
+        isRebuildingPlayer = true
+        isPlayerReady = false
+
+        let asset = AVAsset(url: clipURL)
+        self.asset = asset
+
+        let imageGenerator = AVAssetImageGenerator(asset: asset)
+        imageGenerator.appliesPreferredTrackTransform = true
+        imageGenerator.requestedTimeToleranceBefore = .zero
+        imageGenerator.requestedTimeToleranceAfter = .zero
+        self.imageGenerator = imageGenerator
+
+        Task { @MainActor in
+            do {
+                let durationCMTime = try await asset.load(.duration)
+                let durationSeconds = CMTimeGetSeconds(durationCMTime)
+
+                self.duration = durationSeconds
+
+                guard durationSeconds > 0 else {
+                    self.player.replaceCurrentItem(with: nil)
+                    self.isPlayerReady = false
+                    self.isRebuildingPlayer = false
+                    return
+                }
+
+                self.startPoint = 0
+
+                let item = AVPlayerItem(asset: asset)
+                self.player.replaceCurrentItem(with: item)
+
+                self.isPlayerReady = true
+                self.isRebuildingPlayer = false
+
+                await updatePreviewImage(at: self.startPoint)
+                playPreview()
+
+            } catch {
+                print("Failed to load duration: \(error)")
+                self.player.replaceCurrentItem(with: nil)
+                self.isPlayerReady = false
+                self.isRebuildingPlayer = false
+            }
+        }
+    }
+
+    /// 트리밍된 구간만 보여주도록 player 및 썸네일 설정
+    func trimmedClip(trimStart: Double, trimEnd: Double) async {
+        guard let imageGenerator = imageGenerator else { return }
+        trimOffset = trimStart
+
+        let trimmedDuration = trimEnd - trimStart
+        startPoint = 0
+        duration = trimmedDuration
+
+        seek(to: 0)
+        await updatePreviewImage(at: 0)
+
+        thumbnails = []
+        let interval = trimmedDuration / Double(thumbnailCount)
+
+        let times = (0 ..< thumbnailCount).map { i in
+            CMTime(seconds: trimStart + Double(i) * interval, preferredTimescale: 600)
+        }
+
+        do {
+            for try await result in imageGenerator.images(for: times) {
+                let cgImage = try result.image
+                let uiImage = UIImage(cgImage: cgImage)
+                thumbnails.append(uiImage)
+            }
+        } catch {
+            print("썸네일트리밍 error \(error)")
+        }
+    }
+
+    /// 특정 시간의 프레임을 추출하여 preview 이미지를 갱신
+    func updatePreviewImage(at time: Double) async {
+        guard let imageGenerator = imageGenerator else { return }
+        let actualTime = time + trimOffset
+        let cmTime = CMTime(seconds: actualTime, preferredTimescale: 600)
+        do {
+            let result = try await imageGenerator.image(at: cmTime)
+            previewImage = UIImage(cgImage: result.image)
+        } catch {
+            print(error)
+        }
+    }
+
+    /// 가이드 프레임 시작 지점을 갱신하고 프리뷰 이미지를 갱신
+    func updateStart(_ value: Double) {
+        startPoint = value
+        if currentPlayTime < startPoint {
+            seek(to: startPoint)
+            Task { await updatePreviewImage(at: value) }
+        }
+    }
+
+    /// AVPlayer를 지정된 시간으로 이동
+    func seek(to time: Double, completion: (() -> Void)? = nil) {
+        let actualTime = time + trimOffset
+        let cmTime = CMTime(seconds: actualTime, preferredTimescale: 600)
+        currentPlayTime = time
+        player.seek(
+            to: cmTime,
+            toleranceBefore: .zero,
+            toleranceAfter: .zero
+        ) { _ in
+            completion?()
+        }
+    }
+
+    /// 재생/일시정지 상태 토글
+    func togglePlayback() {
+        isPlaying.toggle()
+        isPlaying ? playPreview() : player.pause()
+    }
+
+    /// 썸네일 하나의 너비 계산
+    func thumbnailUnitWidth(for thumbnailLineWidth: CGFloat) -> CGFloat {
+        let count = max(thumbnails.count, 1)
+        return thumbnailLineWidth / CGFloat(count)
+    }
+
+    /// startX 계산 (가이드 프레임 박스 위치)
+    func startX(thumbnailLineWidth: CGFloat, handleWidth: CGFloat) -> CGFloat {
+        guard duration > 0 else { return handleWidth }
+        let ratio = startPoint / duration
+        return handleWidth + ratio * thumbnailLineWidth
+    }
+
+    /// 트리밍 시작 시점부터 재생을 시작하고, 종료 시점에 도달하면 자동으로 정지
+    func playPreview() {
+        if let token = timeObserverToken {
+            player.removeTimeObserver(token)
+            timeObserverToken = nil
+        }
+
+        let playerRef = player
+        let trimOffset = self.trimOffset
+        let endPoint = duration
+        let startPoint = self.startPoint
+
+        let currentTime = playerRef.currentTime()
+        let currentTimeSeconds = CMTimeGetSeconds(currentTime)
+        let actualStart = startPoint + trimOffset
+        let actualEnd = endPoint + trimOffset
+        let epsilon = 0.001
+
+        func startPlaybackAndObserve() {
+            playerRef.play()
+
+            let token = playerRef.addPeriodicTimeObserver(
+                forInterval: CMTime(seconds: 0.01, preferredTimescale: 600),
+                queue: .main
+            ) { time in
+                let currentSeconds = CMTimeGetSeconds(time)
+                let displaySeconds = currentSeconds - trimOffset
+                let checkEnd = endPoint + trimOffset
+
+                Task { @MainActor in
+                    self.currentPlayTime = displaySeconds
+
+                    if currentSeconds >= checkEnd {
+                        playerRef.pause()
+                        self.isPlaying = false
+
+                        if let token = self.timeObserverToken {
+                            playerRef.removeTimeObserver(token)
+                            self.timeObserverToken = nil
+                        }
+                    }
+                }
+            }
+
+            timeObserverToken = token
+        }
+
+        if currentTimeSeconds >= actualStart, currentTimeSeconds < (actualEnd - epsilon) {
+            isPlaying = true
+            startPlaybackAndObserve()
+        } else {
+            seek(to: startPoint) { [weak self] in
+                guard let self else { return }
+                self.isPlaying = true
+                startPlaybackAndObserve()
+            }
+        }
+    }
+}

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -148,13 +148,15 @@ struct ClipEditView: View {
                 VideoControlView(
                     isDragging: isDragging,
                     overlayImage: guide?.outlineImage,
-                    previewImage: editViewModel.previewImage,
-                    player: editViewModel.player,
-                    isPlayerReady: editViewModel.isPlayerReady,
-                    isRebuildingPlayer: editViewModel.isRebuildingPlayer,
-                    isPlaying: editViewModel.isPlaying,
-                    onTogglePlayback: { editViewModel.togglePlayback() },
-                    currentTrimmedDuration: editViewModel.currentTrimmedDuration
+                    context: VideoContext(
+                        previewImage: editViewModel.previewImage,
+                        player: editViewModel.player,
+                        isPlayerReady: editViewModel.isPlayerReady,
+                        isRebuildingPlayer: editViewModel.isRebuildingPlayer,
+                        isPlaying: editViewModel.isPlaying,
+                        currentTrimmedDuration: editViewModel.currentTrimmedDuration,
+                        onTogglePlayback: { editViewModel.togglePlayback() }
+                    )
                 )
 
                 TrimmingControlView(editViewModel: editViewModel, isDragging: $isDragging)

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -148,7 +148,13 @@ struct ClipEditView: View {
                 VideoControlView(
                     isDragging: isDragging,
                     overlayImage: guide?.outlineImage,
-                    editViewModel: editViewModel
+                    previewImage: editViewModel.previewImage,
+                    player: editViewModel.player,
+                    isPlayerReady: editViewModel.isPlayerReady,
+                    isRebuildingPlayer: editViewModel.isRebuildingPlayer,
+                    isPlaying: editViewModel.isPlaying,
+                    onTogglePlayback: { editViewModel.togglePlayback() },
+                    currentTrimmedDuration: editViewModel.currentTrimmedDuration
                 )
 
                 TrimmingControlView(editViewModel: editViewModel, isDragging: $isDragging)

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -16,7 +16,7 @@ import SwiftUI
  사용자가 영상에서 사용할 구간을 직접 선택(트리밍)할 수 있도록 도와주는 메인 View
  영상 재생, 썸네일 기반 트리밍, 클립 저장, 다음 단계(윤곽선 생성 또는 후속 클립 연결)로 이동하는 역할
 
- ## 데이터 흐름
+ ## 데이터 흐름 
  ⭐️ guide 값(nil 여부)에 따른 분기 처리
  ├─ guide == nil
  │    1) "내보내기" 버튼이 표시되지 않음
@@ -47,7 +47,7 @@ struct ClipEditView: View {
     let cameraManager: CameraManager
 
     // 2. State & ObservedObject
-    @StateObject private var editViewModel: ClipEditViewModel
+    @State private var editViewModel: ClipEditViewModel
     @EnvironmentObject private var coordinator: Coordinator
 //    @StateObject private var videoManager = VideoManager()
     @State private var isDragging = false
@@ -74,7 +74,7 @@ struct ClipEditView: View {
         timeStampedTiltList: [TimeStampedTilt],
         clipID: String? = nil
     ) {
-        _editViewModel = StateObject(wrappedValue: ClipEditViewModel(
+        _editViewModel = State(wrappedValue: ClipEditViewModel(
             clipURL: clipURL,
             cameraSetting: cameraSetting,
             timeStampedTiltList: timeStampedTiltList,

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -32,25 +32,27 @@ import UIKit
     ├─ guide == nil : saveProjectData() 호출 → Clip 및 Project 생성
     └─ guide != nil : appendClipToCurrentProject() 호출 → 기존 Project에 Clip 추가
  */
+
 @MainActor
-final class ClipEditViewModel: ObservableObject {
+@Observable
+final class ClipEditViewModel {
     // 1. Input
     var clipURL: URL
     var cameraSetting: CameraSetting
     var timeStampedTiltList: [TimeStampedTilt]
     
     // 2. Published properties
-    @Published var player: AVPlayer = AVPlayer()
-    @Published var startPoint: Double = 0
-    @Published var endPoint: Double = 0
-    @Published var duration: Double = 0
-    @Published var thumbnails: [UIImage] = []
-    @Published var isPlaying = false
-    @Published var previewImage: UIImage?
-    @Published var clipID: String? = nil
-    @Published var currentPlayTime: Double = 0
-    @Published var isPlayerReady: Bool = false
-    @Published var isRebuildingPlayer: Bool = false
+    var player: AVPlayer = .init()
+    var startPoint: Double = 0
+    var endPoint: Double = 0
+    var duration: Double = 0
+    var thumbnails: [UIImage] = []
+    var isPlaying = false
+    var previewImage: UIImage?
+    var clipID: String?
+    var currentPlayTime: Double = 0
+    var isPlayerReady: Bool = false
+    var isRebuildingPlayer: Bool = false
 
     // 3. 계산 프로퍼티
     /// 현재 트리밍된 영상 길이 (초 단위)
@@ -307,7 +309,7 @@ final class ClipEditViewModel: ObservableObject {
                 }
             }
             
-            self.timeObserverToken = token
+            timeObserverToken = token
         }
 
         // 범위 내면 바로 재생, 아니면 start로 이동 후 재생

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -335,40 +335,6 @@ final class ClipEditViewModel {
         endPoint = newEnd
     }
 
-    /// GuideSelectView에서 트리밍된 구간만 보여주게끔 조정
-    func trimmedClip(trimStart: Double, trimEnd: Double) async {
-        guard let imageGenerator = imageGenerator else { return }
-        // 원본시간
-        trimOffset = trimStart
-
-        // 사용자가 보기에 시작은 0초로 고정
-        let trimmedDuration = trimEnd - trimStart
-        startPoint = 0
-        duration = trimmedDuration
-        endPoint = trimmedDuration
-
-        seek(to: 0)
-
-        await updatePreviewImage(at: 0)
-
-        thumbnails = []
-        let interval = trimmedDuration / Double(thumbnailCount)
-
-        let times = (0 ..< thumbnailCount).map { i in
-            CMTime(seconds: trimStart + Double(i) * interval, preferredTimescale: 600)
-        }
-        
-        do {
-            for try await result in imageGenerator.images(for: times) {
-                let cgImage = try result.image
-                let uiImage = UIImage(cgImage: cgImage)
-                thumbnails.append(uiImage)
-            }
-        } catch {
-            print("썸네일트리밍 error \(error)")
-        }
-    }
-    
     /// Project의 referenceDuration 값을 기반으로
     /// 트리밍 구간(startPoint, endPoint)을 초기화합니다.
     /// 두 번째 촬영 이후부터 호출됩니다.

--- a/Chalkak/Presentation/ClipEdit/SubViews/TrimmingControlView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/TrimmingControlView.swift
@@ -21,7 +21,7 @@ import SwiftUI
  - 호출 예시 : TrimmingControlView(editViewModel: editViewModel, isDragging: $isDragging)
  */
 struct TrimmingControlView: View {
-    @ObservedObject var editViewModel: ClipEditViewModel
+    var editViewModel: ClipEditViewModel
     @Binding var isDragging: Bool
 
     var body: some View {

--- a/Chalkak/Presentation/ClipEdit/SubViews/TrimmingLineView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/TrimmingLineView.swift
@@ -25,7 +25,7 @@ import SwiftUI
 import SwiftUI
 
 struct TrimmingLineView: View {
-    @ObservedObject var editViewModel: ClipEditViewModel
+    var editViewModel: ClipEditViewModel
     @Binding var isDragging: Bool
 
     var body: some View {

--- a/Chalkak/Presentation/ClipEdit/SubViews/TrimmingTimeDisplayView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/TrimmingTimeDisplayView.swift
@@ -19,7 +19,7 @@ import SwiftUI
     TrimmingTimeDisplayView(editViewModel: editViewModel)
  */
 struct TrimmingTimeDisplayView: View {
-    @ObservedObject var editViewModel: ClipEditViewModel
+    var editViewModel: ClipEditViewModel
     
     var body: some View {
         HStack(content: {

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
@@ -30,7 +30,7 @@ import SwiftUI
     )
  */
 struct VideoControlPanelView: View {
-    @ObservedObject var editViewModel: ClipEditViewModel
+    var editViewModel: ClipEditViewModel
     @Binding var isOverlayVisible: Bool
     let showOverlayToggle: Bool
     var displayTime: Double? = nil

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlPanelView.swift
@@ -30,25 +30,27 @@ import SwiftUI
     )
  */
 struct VideoControlPanelView: View {
-    var editViewModel: ClipEditViewModel
+    let isPlaying: Bool
+    let onTogglePlayback: () -> Void
     @Binding var isOverlayVisible: Bool
     let showOverlayToggle: Bool
     var displayTime: Double? = nil
+    var currentTrimmedDuration: Double = 0
 
     private var timeToDisplay: Double {
-        displayTime ?? editViewModel.currentTrimmedDuration
+        displayTime ?? currentTrimmedDuration
     }
 
     var body: some View {
         ZStack(alignment: .center) {
             SnappieButton(
                 .iconBackground(
-                    icon: self.editViewModel.isPlaying ? .pauseFill : .playFill,
+                    icon: isPlaying ? .pauseFill : .playFill,
                     size: .medium,
                     isActive: true
                 )
             ) {
-                self.editViewModel.togglePlayback()
+                onTogglePlayback()
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 24)
@@ -73,10 +75,10 @@ struct VideoControlPanelView: View {
                 .iconBackground(
                     icon: .silhouette,
                     size: .medium,
-                    isActive: self.showOverlayToggle ? self.isOverlayVisible : false
+                    isActive: showOverlayToggle ? isOverlayVisible : false
                 )
             ) {
-                self.isOverlayVisible.toggle()
+                isOverlayVisible.toggle()
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
             .padding(.trailing, 24)

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
@@ -5,8 +5,8 @@
 //  Created by Youbin on 7/24/25.
 //
 
-import SwiftUI
 import AVFoundation
+import SwiftUI
 
 /**
  VideoControlView: 영상 미리보기 및 조작 인터페이스
@@ -23,8 +23,13 @@ import AVFoundation
     VideoControlView(
         isDragging: isDragging,
         overlayImage: guide?.outlineImage,
-        editViewModel: editViewModel,
-        isGuideSelectMode: false
+        previewImage: editViewModel.previewImage,
+        player: editViewModel.player,
+        isPlayerReady: editViewModel.isPlayerReady,
+        isRebuildingPlayer: editViewModel.isRebuildingPlayer,
+        isPlaying: editViewModel.isPlaying,
+        onTogglePlayback: { editViewModel.togglePlayback() },
+        currentTrimmedDuration: editViewModel.currentTrimmedDuration
     )
  */
 struct VideoControlView: View {
@@ -32,27 +37,35 @@ struct VideoControlView: View {
     let overlayImage: UIImage?
     var displayTime: Double? = nil
 
-    var editViewModel: ClipEditViewModel
+    let previewImage: UIImage?
+    let player: AVPlayer
+    let isPlayerReady: Bool
+    let isRebuildingPlayer: Bool
+    let isPlaying: Bool
+    let onTogglePlayback: () -> Void
+    var currentTrimmedDuration: Double = 0
+
     @State private var isOverlayVisible: Bool = true
 
     var body: some View {
-        VStack(alignment: .center, spacing: 16 ,content: {
-
+        VStack(alignment: .center, spacing: 16, content: {
             VideoPreviewWithOverlay(
-                previewImage: editViewModel.previewImage,
-                player: editViewModel.player,
+                previewImage: previewImage,
+                player: player,
                 isDragging: isDragging,
                 overlayImage: overlayImage,
-                isPlayerReady: editViewModel.isPlayerReady,
-                isRebuildingPlayer: editViewModel.isRebuildingPlayer,
+                isPlayerReady: isPlayerReady,
+                isRebuildingPlayer: isRebuildingPlayer,
                 isOverlayVisible: $isOverlayVisible
             )
 
             VideoControlPanelView(
-                editViewModel: editViewModel,
+                isPlaying: isPlaying,
+                onTogglePlayback: onTogglePlayback,
                 isOverlayVisible: $isOverlayVisible,
                 showOverlayToggle: overlayImage != nil,
-                displayTime: displayTime
+                displayTime: displayTime,
+                currentTrimmedDuration: currentTrimmedDuration
             )
         })
     }

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
@@ -32,7 +32,7 @@ struct VideoControlView: View {
     let overlayImage: UIImage?
     var displayTime: Double? = nil
 
-    @ObservedObject var editViewModel: ClipEditViewModel
+    var editViewModel: ClipEditViewModel
     @State private var isOverlayVisible: Bool = true
 
     var body: some View {

--- a/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/VideoControlView.swift
@@ -8,6 +8,16 @@
 import AVFoundation
 import SwiftUI
 
+struct VideoContext {
+    let previewImage: UIImage?
+    let player: AVPlayer
+    let isPlayerReady: Bool
+    let isRebuildingPlayer: Bool
+    let isPlaying: Bool
+    let currentTrimmedDuration: Double
+    let onTogglePlayback: () -> Void
+}
+
 /**
  VideoControlView: 영상 미리보기 및 조작 인터페이스
 
@@ -18,54 +28,49 @@ import SwiftUI
  - VideoControlPanelView: 재생/일시정지 버튼, 트리밍된 길이 표시, 오버레이 on/off 버튼 포함
 
  ## 호출 위치
- - `ClipEditView` 내부에서 영상 조작 뷰로 사용됨
+ - `ClipEditView`, `GuideSelectView` 내부에서 영상 조작 뷰로 사용됨
  - 호출 예시
     VideoControlView(
         isDragging: isDragging,
         overlayImage: guide?.outlineImage,
-        previewImage: editViewModel.previewImage,
-        player: editViewModel.player,
-        isPlayerReady: editViewModel.isPlayerReady,
-        isRebuildingPlayer: editViewModel.isRebuildingPlayer,
-        isPlaying: editViewModel.isPlaying,
-        onTogglePlayback: { editViewModel.togglePlayback() },
-        currentTrimmedDuration: editViewModel.currentTrimmedDuration
+        context: VideoContext(
+            previewImage: editViewModel.previewImage,
+            player: editViewModel.player,
+            isPlayerReady: editViewModel.isPlayerReady,
+            isRebuildingPlayer: editViewModel.isRebuildingPlayer,
+            isPlaying: editViewModel.isPlaying,
+            currentTrimmedDuration: editViewModel.currentTrimmedDuration,
+            onTogglePlayback: { editViewModel.togglePlayback() }
+        )
     )
  */
 struct VideoControlView: View {
     let isDragging: Bool
     let overlayImage: UIImage?
     var displayTime: Double? = nil
-
-    let previewImage: UIImage?
-    let player: AVPlayer
-    let isPlayerReady: Bool
-    let isRebuildingPlayer: Bool
-    let isPlaying: Bool
-    let onTogglePlayback: () -> Void
-    var currentTrimmedDuration: Double = 0
+    let context: VideoContext
 
     @State private var isOverlayVisible: Bool = true
 
     var body: some View {
         VStack(alignment: .center, spacing: 16, content: {
             VideoPreviewWithOverlay(
-                previewImage: previewImage,
-                player: player,
+                previewImage: context.previewImage,
+                player: context.player,
                 isDragging: isDragging,
                 overlayImage: overlayImage,
-                isPlayerReady: isPlayerReady,
-                isRebuildingPlayer: isRebuildingPlayer,
+                isPlayerReady: context.isPlayerReady,
+                isRebuildingPlayer: context.isRebuildingPlayer,
                 isOverlayVisible: $isOverlayVisible
             )
 
             VideoControlPanelView(
-                isPlaying: isPlaying,
-                onTogglePlayback: onTogglePlayback,
+                isPlaying: context.isPlaying,
+                onTogglePlayback: context.onTogglePlayback,
                 isOverlayVisible: $isOverlayVisible,
                 showOverlayToggle: overlayImage != nil,
                 displayTime: displayTime,
-                currentTrimmedDuration: currentTrimmedDuration
+                currentTrimmedDuration: context.currentTrimmedDuration
             )
         })
     }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #29 

## ✨ PR Content
1. 1차적으로 ObservableObject프로토콜 형태의 뷰모델에서 @Observable매크로로 마이그레이션 해주었습니다.
2. ClipEditViewmodel이 중복사용되던 문제를 해결하기위해서 GuideSelectView를 위해서 새롭게 GuideSelectViewModel을 ClipEditViewmodel에서 분리해주었습니다.
3. VideoControlView / VideoControlPanelView 가 뷰모델을 직접 받아서 쓰고 있었는데, 뷰모델 자체를 넘겨주기보다는 필요한 값만 넘겨주는 방식으로 변경해주었습니다.  둘다 중복 사용되는 친구들이라 같은 뷰모델을 넘겨받아야 활용되고 있었는데, 값으로 해서 재활용할 수 있게해줬습니다. 


## 📸 Screenshot
- 구현형태는 이전과 동일합니다. 

## 📍 PR Point 
> 이전에 구현했던게 배포 시기랑 맞물려서 많은 부분이 바뀌는바람에, 충돌 문제가 있을까봐 머지하지않고, 새롭게 develop브랜치에서 작업했습니다. 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
