### PR TITLE
♻️  [refactor] #97 카메라관련 View - ViewModel 코드 구조 개선

### DIFF
--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -21,7 +21,7 @@ struct CameraView: View {
         }
     }
 
-    @StateObject var viewModel = CameraViewModel()
+    @State var viewModel = CameraViewModel()
     @EnvironmentObject private var coordinator: Coordinator
     @Environment(PermissionManager.self) private var permissionManager
 

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -85,7 +85,7 @@ struct CameraView: View {
                     size: .large,
                     isActive: true
                 )) {
-                    handleExitCamera()
+                    viewModel.exitCamera()
                     Analytics.logEvent("exitCameraAlertTapped", parameters: nil)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -144,6 +144,7 @@ struct CameraView: View {
             )
         }
         .onAppear {
+            viewModel.coordinator = coordinator
             permissionManager.reevaluateAndPresentIfNeeded()
 
             if permissionManager.permissionState == .both {
@@ -168,23 +169,6 @@ struct CameraView: View {
         .snappieAlert(isPresented: $viewModel.showProjectSavedAlert, message: "프로젝트가 저장되었습니다")
     }
 
-    private func handleExitCamera() {
-        viewModel.stopCamera()
-
-        // 이제 CameraView는 ProjectEditView를 통해서만 접근이 가능함
-        if let projectID = UserDefaults.standard.string(forKey: UserDefaultKey.currentProjectID) {
-            if let tempProject = SwiftDataManager.shared.fetchProject(byID: projectID),
-               let originalID = tempProject.originalID // Temp 여부에 따라 originalID or projectId
-            {
-                coordinator.popToScreen(.projectEdit(projectID: originalID))
-            } else {
-                coordinator.popToScreen(.projectEdit(projectID: projectID))
-            }
-        } else {
-            // fallback
-            coordinator.removeAll()
-        }
-    }
 }
 
 private extension CameraView {

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -9,48 +9,46 @@ import AVFoundation
 import Combine
 import CoreMotion
 import Foundation
+import Observation
 import Photos
 import SwiftData
 import SwiftUI
 
-class CameraViewModel: ObservableObject {
-    // MARK: - Published Properties (UI State)
+@Observable
+class CameraViewModel {
+    // MARK: - Properties (UI State)
 
     // 뷰가 직접 구독하는 상태 변수들을 그룹화합니다.
-    @Published var needsPermissionRequest = false
-    @Published var isTimerRunning = false
-    @Published var selectedTimerDuration: TimerOptions = .off
-    @Published var showTimerFeedback: TimerOptions? = nil
-    @Published var showingCameraControl = false
-    @Published var torchMode: TorchMode = .off
-    @Published var isGrid = false
-    @Published var isHorizontalLevelActive = false {
+    var needsPermissionRequest = false
+    var isTimerRunning = false
+    var selectedTimerDuration: TimerOptions = .off
+    var showTimerFeedback: TimerOptions?
+    var showingCameraControl = false
+    var torchMode: TorchMode = .off
+    var isGrid = false
+    var isHorizontalLevelActive = false {
         didSet { isHorizontalLevelActive ? startObservingTilt() : stopObservingTilt() }
     }
 
-    @Published var isHorizontal = false
-    @Published var cameraPostion: AVCaptureDevice.Position = .back {
+    var isHorizontal = false
+    var cameraPostion: AVCaptureDevice.Position = .back {
         didSet { isUsingFrontCamera = (cameraPostion == .front) }
     }
 
-    @Published var isRecording = false
-    @Published var recordingTime = 0
-    @Published var timerCountdown = 0
-    @Published var showingZoomControl = false
-    @Published var zoomScale: CGFloat = 1.0
-    @Published var isUsingFrontCamera: Bool = false
-    @Published var isPreviewMirrored: Bool = false
-    @Published var hasBadge: Bool = false
-    @Published var showProjectSavedAlert: Bool = false
-    @Published var lastZoomInteraction = Date() // 줌 슬라이더 타이머 로직을 위해 유지
-
-    // MARK: - Core Dependencies & Models
+    var isRecording = false
+    var recordingTime = 0
+    var timerCountdown = 0
+    var showingZoomControl = false
+    var zoomScale: CGFloat = 1.0
+    var isUsingFrontCamera: Bool = false
+    var isPreviewMirrored: Bool = false
+    var hasBadge: Bool = false
+    var showProjectSavedAlert: Bool = false
+    var lastZoomInteraction = Date() // 줌 슬라이더 타이머 로직을 위해 유지
 
     var model: CameraManager
     private let swiftDataManager = SwiftDataManager.shared
-    @Published var tiltCollector = TiltDataCollector()
-
-    // MARK: Internal State
+    var tiltCollector = TiltDataCollector()
 
     let session: AVCaptureSession
     let videoSavedPublisher = PassthroughSubject<URL, Never>()
@@ -67,23 +65,21 @@ class CameraViewModel: ObservableObject {
     private var dataCollectionTimer: Timer?
     private var recordingStartDate: Date?
 
-    // MARK: - Computed Properties
-
     var minZoomScale: CGFloat { 0.5 }
     var maxZoomScale: CGFloat { 6.0 }
     var formattedTime: String { String(format: "%02d:%02d", recordingTime / 60, recordingTime % 60) }
     var currentTimerIcon: Icon { selectedTimerDuration.icon }
     var currentFlashIcon: Icon { torchMode.icon }
 
-    // MARK: - init
-
     init() {
-        model = CameraManager()
-        session = model.session
-        model.$isRecording
-            .assign(to: &$isRecording)
+        let cameraManager = CameraManager()
+        model = cameraManager
+        session = cameraManager.session
+        cameraManager.$isRecording
+            .sink { [weak self] value in self?.isRecording = value }
+            .store(in: &cancellables)
 
-        model.savedVideoInfo
+        cameraManager.savedVideoInfo
             .receive(on: DispatchQueue.main)
             .sink { [weak self] url in
                 self?.videoSavedPublisher.send(url)
@@ -103,7 +99,7 @@ class CameraViewModel: ObservableObject {
         setPreviewMirroringUpdateHandler()
     }
 
-    // MARK: - Camera Set
+    // MARK: 카메라 세팅 관련 함수들
 
     func startCamera() {
         tiltCollector.start()

--- a/Chalkak/Presentation/Camera/CameraViewModel.swift
+++ b/Chalkak/Presentation/Camera/CameraViewModel.swift
@@ -50,6 +50,7 @@ class CameraViewModel {
     private let swiftDataManager = SwiftDataManager.shared
     var tiltCollector = TiltDataCollector()
 
+    weak var coordinator: Coordinator?
     let session: AVCaptureSession
     let videoSavedPublisher = PassthroughSubject<URL, Never>()
     var timeStampedTiltList: [TimeStampedTilt] = []
@@ -110,6 +111,24 @@ class CameraViewModel {
         if isRecording { stopVideoRecording() }
         tiltCollector.stop()
         model.stopSession()
+    }
+
+    @MainActor func exitCamera() {
+        stopCamera()
+
+        // 이제 CameraView는 ProjectEditView를 통해서만 접근이 가능함
+        guard let projectID = UserDefaults.standard.string(forKey: UserDefaultKey.currentProjectID) else {
+            coordinator?.removeAll()
+            return
+        }
+
+        if let tempProject = swiftDataManager.fetchProject(byID: projectID),
+           let originalID = tempProject.originalID // Temp 여부에 따라 originalID or projectId
+        {
+            coordinator?.popToScreen(.projectEdit(projectID: originalID))
+        } else {
+            coordinator?.popToScreen(.projectEdit(projectID: projectID))
+        }
     }
 
     func switchCameraControls() { showingCameraControl.toggle() }

--- a/Chalkak/Presentation/Camera/SubViews/CameraBaseFeatureSelectView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraBaseFeatureSelectView.swift
@@ -9,7 +9,7 @@ import FirebaseAnalytics
 import SwiftUI
 
 struct CameraBaseFeatureSelectView: View {
-    @ObservedObject var viewModel: CameraViewModel
+    var viewModel: CameraViewModel
 
     var body: some View {
         ButtonIconWithText(title: "Timer", icon: viewModel.currentTimerIcon, isActive: viewModel.selectedTimerDuration != .off) {

--- a/Chalkak/Presentation/Camera/SubViews/CameraBottomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraBottomControlView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CameraBottomControlView: View {
-    @ObservedObject var viewModel: CameraViewModel
+    var viewModel: CameraViewModel
 
     var body: some View {
         VStack(spacing: 20) {

--- a/Chalkak/Presentation/Camera/SubViews/CameraDefaultTopControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraDefaultTopControlView.swift
@@ -9,7 +9,7 @@ import FirebaseAnalytics
 import SwiftUI
 
 struct CameraDefaultTopControlView: View {
-    @ObservedObject var viewModel: CameraViewModel
+    var viewModel: CameraViewModel
 
     var body: some View {
         VStack(spacing: 8) {

--- a/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraRecordView.swift
@@ -10,7 +10,7 @@ import SwiftData
 import SwiftUI
 
 struct CameraRecordView: View {
-    @ObservedObject var viewModel: CameraViewModel
+    var viewModel: CameraViewModel
     @EnvironmentObject private var coordinator: Coordinator
 
     var body: some View {

--- a/Chalkak/Presentation/Camera/SubViews/CameraTopControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraTopControlView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CameraTopControlView: View {
-    @ObservedObject var viewModel: CameraViewModel
+    var viewModel: CameraViewModel
     let guide: Guide?
 
     var body: some View {

--- a/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
+++ b/Chalkak/Presentation/Camera/SubViews/CameraZoomControlView.swift
@@ -9,7 +9,7 @@ import FirebaseAnalytics
 import SwiftUI
 
 struct CameraZoomControlView: View {
-    @ObservedObject var viewModel: CameraViewModel
+    var viewModel: CameraViewModel
     @State private var longPressStarted = false
 
     // 줌 활성범위

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -205,6 +205,9 @@ struct ClipEditView: View {
                 editViewModel.applyReferenceDuration()
             }
         }
+        .onAppear {
+            editViewModel.restorePlayer()
+        }
         .onDisappear {
             editViewModel.cleanup()
         }

--- a/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditViewModel.swift
@@ -149,6 +149,12 @@ final class ClipEditViewModel {
         player.pause()
         player.replaceCurrentItem(with: nil)
     }
+
+    ///  가이드선택 -> 장면 다듬기로 돌아갔을때 cleanup으로 날아간 player복구
+    func restorePlayer() {
+        guard player.currentItem == nil else { return }
+        setupPlayer()
+    }
     
     /// 영상 전체 길이와 썸네일 간격을 계산하여, 일정 시간 간격으로 트리밍 타임라인 썸네일 이미지 생성
     func generateThumbnails() async {

--- a/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FirstShootCameraView: View {
     @State private var viewModel = BoundingBoxViewModel()
-    @StateObject private var cameraViewModel = CameraViewModel()
+    @State private var cameraViewModel = CameraViewModel()
 
     var body: some View {
         ZStack {

--- a/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
@@ -12,14 +12,14 @@ struct GuideCameraView: View {
     let shootState: ShootState
     
     @State private var viewModel = BoundingBoxViewModel()
-    @StateObject private var cameraViewModel = CameraViewModel()
+    @State private var cameraViewModel = CameraViewModel()
 
     init(guide: Guide?, shootState: ShootState) {
         self.guide = guide
         self.shootState = shootState
 
         let cameraVM = CameraViewModel()
-        self._cameraViewModel = StateObject(wrappedValue: cameraVM)
+        self._cameraViewModel = State(wrappedValue: cameraVM)
         self._viewModel = State(
             wrappedValue: BoundingBoxViewModel(
                 properTilt: guide?.cameraTilt,


### PR DESCRIPTION
## 🔖  해결한 이슈 

- Resolved: #97 

1. CameraView에 끼어있던 데이터 로직을 ViewModel로 이동했습니다.  (`handleExitCamera()`)

2. CameraViewModel - ObservableObject -> @Observable 마이그레이션

3. ClipEditView 화면 복귀 시 버그 수정
- 장면 다듬기 화면에서 가이드 선택 화면으로 이동하면 onDisappear가 호출되면서 cleanup()이 실행되는데요..! 가이드 선택 후 다시 돌아왔을 때 복구 로직이 없어서 영상이 까만색 화면으로 표시되는 버그가 있었습니다.
```swift
func cleanup() {
      player.removeTimeObserver(token)
      player.pause()              
      player.replaceCurrentItem(with: nil) // 문제의 부분
  }
```
cleanup()이 영상 데이터를 태워버리는데, 가이드 선택페이지에서 뒤돌아가기로 다시 돌아왔을 때는 보여줄 영상 아이템이 없어진 상태인거죠..!

그래서 만든게  restorePlayer인데, onAppear 시점에 플레이어 아이템이 없는 경우에만 setupPlayer()를 재호출하도록 했습니다.
```swift
 func restorePlayer() {
      guard player.currentItem == nil else { return } 
      setupPlayer() // 영상 데이터 다시 로드
  }

## ✨ PR Content
> 작업 내용 설명을 적어주세요.
상단에 설명을 함께추가했습니다 ! 

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 특이 사항 1
- 특이 사항 2

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
