### PR TITLE
✨ [Feat] 가이드 및 라이브 박스 인식 범위를 사람+사물로 확장

### DIFF
--- a/Chalkak.xcodeproj/project.pbxproj
+++ b/Chalkak.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7D17CABC2EEFE93C00C26529 /* StartProjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D17CABB2EEFE93C00C26529 /* StartProjectView.swift */; };
 		7D3DFFD42EFD5E9C00E15204 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3DFFD32EFD5E9C00E15204 /* PermissionManager.swift */; };
 		7D3DFFD82EFD604600E15204 /* PermissionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D3DFFD72EFD604200E15204 /* PermissionState.swift */; };
+		7D49A77A2FC1EC270003D691 /* MaskBoundingBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D49A7792FC1EC270003D691 /* MaskBoundingBox.swift */; };
 		7D60F6492F0D141800621874 /* SchemaV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D60F6482F0D141700621874 /* SchemaV3.swift */; };
 		7DD5117A2F5FF740005A4701 /* GuideSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD511792F5FF740005A4701 /* GuideSelectViewModel.swift */; };
 		7DD82CBB2EFEA2E400AD8DFC /* GuideSelectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD82CBA2EFEA2E400AD8DFC /* GuideSelectView.swift */; };
@@ -180,6 +181,7 @@
 		7D17CABB2EEFE93C00C26529 /* StartProjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartProjectView.swift; sourceTree = "<group>"; };
 		7D3DFFD32EFD5E9C00E15204 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
 		7D3DFFD72EFD604200E15204 /* PermissionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionState.swift; sourceTree = "<group>"; };
+		7D49A7792FC1EC270003D691 /* MaskBoundingBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskBoundingBox.swift; sourceTree = "<group>"; };
 		7D60F6482F0D141700621874 /* SchemaV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV3.swift; sourceTree = "<group>"; };
 		7DD511792F5FF740005A4701 /* GuideSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideSelectViewModel.swift; sourceTree = "<group>"; };
 		7DD82CBA2EFEA2E400AD8DFC /* GuideSelectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideSelectView.swift; sourceTree = "<group>"; };
@@ -500,6 +502,7 @@
 				993A1F122E267E0C0059B70A /* Distance */,
 				993A1F182E267E0C0059B70A /* Overlay */,
 				993A1F1C2E267E0C0059B70A /* Tilt */,
+				7D49A7792FC1EC270003D691 /* MaskBoundingBox.swift */,
 			);
 			path = Guide;
 			sourceTree = "<group>";
@@ -1150,6 +1153,7 @@
 				9999924B2E2D8ED600D56BD1 /* UserDefaultKey.swift in Sources */,
 				993A1F5F2E267E0C0059B70A /* Clip.swift in Sources */,
 				99C7266C2E2F06A200E9D0CD /* GuideCameraView.swift in Sources */,
+				7D49A77A2FC1EC270003D691 /* MaskBoundingBox.swift in Sources */,
 				993A1F602E267E0C0059B70A /* Guide.swift in Sources */,
 				9340078B2E340445006BE89C /* TrimmingTimeDisplayView.swift in Sources */,
 				0D5512FB2E541762001FA7F9 /* OnboardingSubView.swift in Sources */,

--- a/Chalkak/Core/Guide/Distance/BoundingBoxManager.swift
+++ b/Chalkak/Core/Guide/Distance/BoundingBoxManager.swift
@@ -11,30 +11,53 @@ import Vision
 class BoundingBoxManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
     var onMultiBoundingBoxUpdate: (([CGRect]) -> Void)?
 
+    private var frameCounter = 0
+    /// 매 N프레임마다 한 번씩만 인식 (30fps 입력 → ≈10fps 인식)
+    /// 촬영/프리뷰 프레임에는 영향 없음
+    private let frameInterval = 3
+
     func captureOutput(_ output: AVCaptureOutput,
                        didOutput sampleBuffer: CMSampleBuffer,
                        from connection: AVCaptureConnection) {
+        frameCounter &+= 1
+        guard frameCounter % frameInterval == 0 else { return }
+
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
 
-        let request = VNDetectHumanRectanglesRequest { [weak self] req, _ in
-            guard let results = req.results as? [VNHumanObservation] else {
-                DispatchQueue.main.async {
+        let request = VNGenerateForegroundInstanceMaskRequest()
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer,
+                                            orientation: .right,
+                                            options: [:])
+        do {
+            try handler.perform([request])
+
+            guard let result = request.results?.first as? VNInstanceMaskObservation else {
+                DispatchQueue.main.async { [weak self] in
                     self?.onMultiBoundingBoxUpdate?([])
                 }
                 return
             }
 
-            let boxes = results.map { $0.boundingBox }
-            DispatchQueue.main.async {
+            let maskedBuffer = try result.generateMaskedImage(
+                ofInstances: result.allInstances,
+                from: handler,
+                croppedToInstancesExtent: false
+            )
+
+            let boxes: [CGRect]
+            if let unionBox = unionBoundingBox(fromMaskedBuffer: maskedBuffer) {
+                boxes = [unionBox]
+            } else {
+                boxes = []
+            }
+
+            DispatchQueue.main.async { [weak self] in
                 self?.onMultiBoundingBoxUpdate?(boxes)
             }
+        } catch {
+            DispatchQueue.main.async { [weak self] in
+                self?.onMultiBoundingBoxUpdate?([])
+            }
         }
-
-        request.upperBodyOnly = true
-
-        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer,
-                                            orientation: .right,
-                                            options: [:])
-        try? handler.perform([request])
     }
 }

--- a/Chalkak/Core/Guide/Distance/BoundingBoxManager.swift
+++ b/Chalkak/Core/Guide/Distance/BoundingBoxManager.swift
@@ -45,7 +45,7 @@ class BoundingBoxManager: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate
             )
 
             let boxes: [CGRect]
-            if let unionBox = unionBoundingBox(fromMaskedBuffer: maskedBuffer) {
+            if let unionBox = unionBoundingBox(from: maskedBuffer) {
                 boxes = [unionBox]
             } else {
                 boxes = []

--- a/Chalkak/Core/Guide/MaskBoundingBox.swift
+++ b/Chalkak/Core/Guide/MaskBoundingBox.swift
@@ -12,7 +12,7 @@ import Foundation
 
 /// 마스크된 BGRA 이미지의 알파 채널에서 non-zero 픽셀 합집합 영역을
 /// Vision 정규화 좌표(원점 좌하단)로 반환
-func unionBoundingBox(fromMaskedBuffer maskedBuffer: CVPixelBuffer) -> CGRect? {
+func unionBoundingBox(from maskedBuffer: CVPixelBuffer) -> CGRect? {
     let width = CVPixelBufferGetWidth(maskedBuffer)
     let height = CVPixelBufferGetHeight(maskedBuffer)
     let bytesPerRow = CVPixelBufferGetBytesPerRow(maskedBuffer)

--- a/Chalkak/Core/Guide/MaskBoundingBox.swift
+++ b/Chalkak/Core/Guide/MaskBoundingBox.swift
@@ -1,0 +1,52 @@
+//
+//  MaskBoundingBox.swift
+//  Chalkak
+//
+//  Created by bishoe01 on 23/5/26.
+//  VNGenerateForegroundInstanceMaskRequest로 생성된 마스크 이미지의
+//  union bounding box를 계산하는 공용 유틸
+//
+
+import CoreVideo
+import Foundation
+
+/// 마스크된 BGRA 이미지의 알파 채널에서 non-zero 픽셀 합집합 영역을
+/// Vision 정규화 좌표(원점 좌하단)로 반환
+func unionBoundingBox(fromMaskedBuffer maskedBuffer: CVPixelBuffer) -> CGRect? {
+    let width = CVPixelBufferGetWidth(maskedBuffer)
+    let height = CVPixelBufferGetHeight(maskedBuffer)
+    let bytesPerRow = CVPixelBufferGetBytesPerRow(maskedBuffer)
+
+    CVPixelBufferLockBaseAddress(maskedBuffer, .readOnly)
+    defer { CVPixelBufferUnlockBaseAddress(maskedBuffer, .readOnly) }
+
+    guard let base = CVPixelBufferGetBaseAddress(maskedBuffer) else { return nil }
+    let bytes = base.assumingMemoryBound(to: UInt8.self)
+
+    var minX = width
+    var minY = height
+    var maxX = -1
+    var maxY = -1
+
+    // BGRA 픽셀의 알파 채널(offset +3)이 0보다 크면 전경
+    for y in 0..<height {
+        let rowStart = y * bytesPerRow
+        for x in 0..<width where bytes[rowStart + x * 4 + 3] > 0 {
+            if x < minX { minX = x }
+            if x > maxX { maxX = x }
+            if y < minY { minY = y }
+            if y > maxY { maxY = y }
+        }
+    }
+
+    guard maxX >= 0, maxY >= 0 else { return nil }
+
+    let w = CGFloat(width)
+    let h = CGFloat(height)
+    return CGRect(
+        x: CGFloat(minX) / w,
+        y: 1.0 - CGFloat(maxY + 1) / h,
+        width: CGFloat(maxX - minX + 1) / w,
+        height: CGFloat(maxY - minY + 1) / h
+    )
+}

--- a/Chalkak/Core/Guide/Overlay/OverlayManager.swift
+++ b/Chalkak/Core/Guide/Overlay/OverlayManager.swift
@@ -74,7 +74,7 @@ class OverlayManager: ObservableObject {
 
                 /// 4단계: 마스크 알파 채널에서 union BoundingBox 추출
                 let unionBoxes: [CGRect]
-                if let unionBox = unionBoundingBox(fromMaskedBuffer: maskedPixelBuffer) {
+                if let unionBox = unionBoundingBox(from: maskedPixelBuffer) {
                     let correctedBox: CGRect
                     if isFront {
                         // 좌우 반전

--- a/Chalkak/Core/Guide/Overlay/OverlayManager.swift
+++ b/Chalkak/Core/Guide/Overlay/OverlayManager.swift
@@ -35,17 +35,15 @@ class OverlayManager: ObservableObject {
     // 2. Private 저장 프로퍼티
     private let context = CIContext()
 
-    //MARK: - 인물 마스킹
-    /// 영상에서 사람의 마스킹하여 추출 -> outlineImage로 변환
+    //MARK: - 전경 인스턴스 마스킹
+    /// 영상에서 사람+사물 전경 인스턴스를 마스킹 → union bounding box + outlineImage 추출
     /// - Parameters:
     ///   - image: 입력 원본 CIImage (주로 영상 프레임)
     func process(image: CIImage, completion: @escaping () -> Void) {
         // 1. Vision 요청 준비
-        let rectangleRequest = VNDetectHumanRectanglesRequest()
         let maskRequest = VNGenerateForegroundInstanceMaskRequest()
-        rectangleRequest.upperBodyOnly = true
         let handler = VNImageRequestHandler(ciImage: image, options: [:])
-        
+
         let isFront: Bool
         if let savedValue = UserDefaults.standard.string(forKey: UserDefaultKey.cameraPosition) {
             isFront = (savedValue == "front")
@@ -55,43 +53,48 @@ class OverlayManager: ObservableObject {
 
         DispatchQueue.global().async {
             do {
-                try handler.perform([rectangleRequest, maskRequest])
+                try handler.perform([maskRequest])
 
-                /// 2단계: BoundingBox 추출
-                if let results = rectangleRequest.results, !results.isEmpty {
-                    let correctedBoxes = results.map { observation -> CGRect in
-                            let box = observation.boundingBox
-                            if isFront {
-                                // 좌우 반전
-                                return CGRect(
-                                    x: 1 - box.origin.x - box.size.width,
-                                    y: box.origin.y,
-                                    width: box.size.width,
-                                    height: box.size.height
-                                )
-                            } else {
-                                return box
-                            }
-                        }
-
-                    DispatchQueue.main.async {
-                        self.boundingBoxes = correctedBoxes
-                    }
-                }
-
-                /// 3단계: 마스크 생성
+                /// 2단계: 마스크 생성
                 guard let maskResult = maskRequest.results?.first as? VNInstanceMaskObservation else {
                     print("❌ 마스크 결과 없음")
-                    DispatchQueue.main.async { completion() }
+                    DispatchQueue.main.async {
+                        self.boundingBoxes = []
+                        completion()
+                    }
                     return
                 }
 
-                /// 4단계: 마스크된 이미지 생성
+                /// 3단계: 마스크된 이미지 생성
                 let maskedPixelBuffer = try maskResult.generateMaskedImage(
                     ofInstances: maskResult.allInstances,
                     from: handler,
                     croppedToInstancesExtent: false
                 )
+
+                /// 4단계: 마스크 알파 채널에서 union BoundingBox 추출
+                let unionBoxes: [CGRect]
+                if let unionBox = self.unionBoundingBox(from: maskedPixelBuffer) {
+                    let correctedBox: CGRect
+                    if isFront {
+                        // 좌우 반전
+                        correctedBox = CGRect(
+                            x: 1 - unionBox.origin.x - unionBox.size.width,
+                            y: unionBox.origin.y,
+                            width: unionBox.size.width,
+                            height: unionBox.size.height
+                        )
+                    } else {
+                        correctedBox = unionBox
+                    }
+                    unionBoxes = [correctedBox]
+                } else {
+                    unionBoxes = []
+                }
+                DispatchQueue.main.async {
+                    self.boundingBoxes = unionBoxes
+                }
+
                 let ciImage = CIImage(cvPixelBuffer: maskedPixelBuffer)
 
                 DispatchQueue.main.async {
@@ -113,6 +116,47 @@ class OverlayManager: ObservableObject {
                 DispatchQueue.main.async { completion() }
             }
         }
+    }
+
+    //MARK: - 마스크 union bounding box 계산
+    /// 마스크된 BGRA 이미지의 알파 채널에서 non-zero 픽셀 합집합 영역을 Vision 정규화 좌표(원점 좌하단)로 반환
+    private func unionBoundingBox(from maskedBuffer: CVPixelBuffer) -> CGRect? {
+        let width = CVPixelBufferGetWidth(maskedBuffer)
+        let height = CVPixelBufferGetHeight(maskedBuffer)
+        let bytesPerRow = CVPixelBufferGetBytesPerRow(maskedBuffer)
+
+        CVPixelBufferLockBaseAddress(maskedBuffer, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(maskedBuffer, .readOnly) }
+
+        guard let base = CVPixelBufferGetBaseAddress(maskedBuffer) else { return nil }
+        let bytes = base.assumingMemoryBound(to: UInt8.self)
+
+        var minX = width
+        var minY = height
+        var maxX = -1
+        var maxY = -1
+
+        // BGRA 픽셀의 알파 채널(offset +3)이 0보다 크면 전경
+        for y in 0..<height {
+            let rowStart = y * bytesPerRow
+            for x in 0..<width where bytes[rowStart + x * 4 + 3] > 0 {
+                if x < minX { minX = x }
+                if x > maxX { maxX = x }
+                if y < minY { minY = y }
+                if y > maxY { maxY = y }
+            }
+        }
+
+        guard maxX >= 0, maxY >= 0 else { return nil }
+
+        let w = CGFloat(width)
+        let h = CGFloat(height)
+        return CGRect(
+            x: CGFloat(minX) / w,
+            y: 1.0 - CGFloat(maxY + 1) / h,
+            width: CGFloat(maxX - minX + 1) / w,
+            height: CGFloat(maxY - minY + 1) / h
+        )
     }
 
     //MARK: - 실루엣 오버레이 이미지 생성

--- a/Chalkak/Core/Guide/Overlay/OverlayManager.swift
+++ b/Chalkak/Core/Guide/Overlay/OverlayManager.swift
@@ -74,7 +74,7 @@ class OverlayManager: ObservableObject {
 
                 /// 4단계: 마스크 알파 채널에서 union BoundingBox 추출
                 let unionBoxes: [CGRect]
-                if let unionBox = self.unionBoundingBox(from: maskedPixelBuffer) {
+                if let unionBox = unionBoundingBox(fromMaskedBuffer: maskedPixelBuffer) {
                     let correctedBox: CGRect
                     if isFront {
                         // 좌우 반전
@@ -116,47 +116,6 @@ class OverlayManager: ObservableObject {
                 DispatchQueue.main.async { completion() }
             }
         }
-    }
-
-    //MARK: - 마스크 union bounding box 계산
-    /// 마스크된 BGRA 이미지의 알파 채널에서 non-zero 픽셀 합집합 영역을 Vision 정규화 좌표(원점 좌하단)로 반환
-    private func unionBoundingBox(from maskedBuffer: CVPixelBuffer) -> CGRect? {
-        let width = CVPixelBufferGetWidth(maskedBuffer)
-        let height = CVPixelBufferGetHeight(maskedBuffer)
-        let bytesPerRow = CVPixelBufferGetBytesPerRow(maskedBuffer)
-
-        CVPixelBufferLockBaseAddress(maskedBuffer, .readOnly)
-        defer { CVPixelBufferUnlockBaseAddress(maskedBuffer, .readOnly) }
-
-        guard let base = CVPixelBufferGetBaseAddress(maskedBuffer) else { return nil }
-        let bytes = base.assumingMemoryBound(to: UInt8.self)
-
-        var minX = width
-        var minY = height
-        var maxX = -1
-        var maxY = -1
-
-        // BGRA 픽셀의 알파 채널(offset +3)이 0보다 크면 전경
-        for y in 0..<height {
-            let rowStart = y * bytesPerRow
-            for x in 0..<width where bytes[rowStart + x * 4 + 3] > 0 {
-                if x < minX { minX = x }
-                if x > maxX { maxX = x }
-                if y < minY { minY = y }
-                if y > maxY { maxY = y }
-            }
-        }
-
-        guard maxX >= 0, maxY >= 0 else { return nil }
-
-        let w = CGFloat(width)
-        let h = CGFloat(height)
-        return CGRect(
-            x: CGFloat(minX) / w,
-            y: 1.0 - CGFloat(maxY + 1) / h,
-            width: CGFloat(maxX - minX + 1) / w,
-            height: CGFloat(maxY - minY + 1) / h
-        )
     }
 
     //MARK: - 실루엣 오버레이 이미지 생성

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditView.swift
@@ -176,6 +176,7 @@ struct ProjectEditView: View {
                         viewModel.deleteClip(id: selectedClipID)
                     },
                     onTapExportClip: {
+                        viewModel.isExportingClip = true
                         showClipExportAlert = true
                         Task { await viewModel.exportSelectedClip() }
                     }

--- a/Chalkak/Presentation/ProjectPreview/ProjectPreviewView.swift
+++ b/Chalkak/Presentation/ProjectPreview/ProjectPreviewView.swift
@@ -16,9 +16,7 @@ struct ProjectPreviewView: View {
     @StateObject private var viewModel: ProjectPreviewViewModel
     @Environment(\.dismiss) private var dismiss
     
-    @State private var showExportSuccessAlert = false
     @State private var showPhotoPermissionDeniedAlert = false
-    @State private var isExporting = false
 
     // MARK: Init
 
@@ -56,10 +54,6 @@ struct ProjectPreviewView: View {
             loadingMessage: viewModel.loadingMessage,
             completionMessage: "내보내기 완료"
         )
-        .snappieAlert(
-            isPresented: $showExportSuccessAlert,
-            message: "내보내기 완료"
-        )
         .alert(
             .photoPermissionDenied,
             isPresented: $showPhotoPermissionDeniedAlert,
@@ -72,9 +66,7 @@ struct ProjectPreviewView: View {
         .onAppear {
             Task {
                 let success = await viewModel.exportAndSetPlayer()
-                if success {
-                    showExportSuccessAlert = true
-                } else {
+                if !success {
                     showPhotoPermissionDeniedAlert = true
                 }
             }


### PR DESCRIPTION
## 🔖  해결한 이슈 
- Resolved: #104 ,#105

## ✨ PR Content

`#104`
 - **기존**: 가이드 실루엣 → 사람+사물 / 정렬 기준 박스 → 사람만. 강아지가 실루엣에 보여도 정렬엔 반영 안 됨
- **변경**: 가이드 생성 + 라이브 촬영 모두, 정렬 기준 박스도 사람+사물 포함 union 박스 1개로 통일

`#105`
- **기존**: 알럿 표시 플래그(showClipExportAlert)를 먼저 켜고 내보내기 Task를 시작해서, 로딩 상태가 반영되기 전 한 프레임 동안 분기로 진입 → 완료 알럿이 두 번 노출됨.

- **변경** : 내보내기 Task 시작 전에 viewModel.isExportingClip = true를 동기적으로 먼저 세팅하여 알럿이 처음부터 로딩 상태로 진입하도록 수정 → 완료 알럿이 1회만 표시됨.

### 영향 범위
- `OverlayManager` — 가이드 생성 시 박스 추출
- `BoundingBoxManager` — 라이브 박스 추출 (촬영/프리뷰 30fps 유지, 인식만 10fps throttling)
- `MaskBoundingBox.swift` 신규 — union bbox 추출 공용 유틸
<img width=250 alt="image" src="https://github.com/user-attachments/assets/8e74cdd1-0cb4-4e82-bb1e-4f62ac3045ff" />

### 사물 가이드 정확도 인식
<img width=250  alt="image" src="https://github.com/user-attachments/assets/2deae079-3355-4d3d-a04a-2bde565e71b2" />


## 📍 PR Point 

- `BoundingBoxInfo`가 `scale` 한 값으로 정사각형 박스를 저장하는 구조라, union 박스의 가로/세로 비율이 다양해지면 왜곡 저장될 수 있어요. 일단 두고 실측 후 필요하면 손볼 예정
- 라이브 인식은 `frameInterval = 3`으로 10fps 적용했는데, 촬영 FPS가아니라 박스인식-일치여부판단 이라서, 유저입장에서는 기존 촬영과 동일하게 진행이 가능합니다. 

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인


주요 변경:
- PR Content 영향 범위에 BoundingBoxManager + 신규 유틸 파일 추가
- PR Point의 미완성 문장은 제거 (라이브쪽도 통일했으니 그 트레이드오프 자체가 해소됨)
- 대신 throttling 값 조정 가능하다는 점 + Xcode 파일 추가 안내 추가