### PR TITLE
🐛 [fix] #106 가이드/라이브 박스 좌표계 정렬로 거리 피드백 개선

### DIFF
--- a/Chalkak/Core/CameraKit/CameraManager.swift
+++ b/Chalkak/Core/CameraKit/CameraManager.swift
@@ -522,14 +522,13 @@ private extension CameraManager {
             }
         }
 
-        // videoOutput도 파일 좌표계와 맞추기 위한 동일 처리
+        // 거리 인식(detection)용 videoOutput은 절대 미러링하지 않는다.
+        // 가이드 박스는 미러링되지 않은 좌표계(가이드 영상의 preferredTransform 기준)로 저장되므로
+        // 라이브 인식도 동일하게 비미러 상태여야 전/후면 모두 좌표가 일치한다.
+        // (전면에서 미러링 시, BoundingBoxManager의 .right 회전과 결합되어 박스가 상하 반전됨)
         if let conn = videoOutput.connection(with: .video), conn.isVideoMirroringSupported {
-            switch recordingMirrorPolicy {
-            case .followPreview: conn.isVideoMirrored = isPreviewMirrored
-            case .alwaysMirrored: conn.isVideoMirrored = true
-            case .neverMirrored: conn.isVideoMirrored = false
-            }
             conn.automaticallyAdjustsVideoMirroring = false
+            conn.isVideoMirrored = false
         }
     }
 }

--- a/Chalkak/Core/Guide/Overlay/OverlayManager.swift
+++ b/Chalkak/Core/Guide/Overlay/OverlayManager.swift
@@ -44,13 +44,6 @@ class OverlayManager: ObservableObject {
         let maskRequest = VNGenerateForegroundInstanceMaskRequest()
         let handler = VNImageRequestHandler(ciImage: image, options: [:])
 
-        let isFront: Bool
-        if let savedValue = UserDefaults.standard.string(forKey: UserDefaultKey.cameraPosition) {
-            isFront = (savedValue == "front")
-        } else {
-            isFront = false
-        }
-
         DispatchQueue.global().async {
             do {
                 try handler.perform([maskRequest])
@@ -73,21 +66,12 @@ class OverlayManager: ObservableObject {
                 )
 
                 /// 4단계: 마스크 알파 채널에서 union BoundingBox 추출
+                /// 라이브 인식(BoundingBoxManager) 및 outline 이미지와 동일한 좌표계를 유지해야
+                /// 비교가 맞으므로 전면 좌우반전 보정을 하지 않는다.
+                /// (전면 녹화/프리뷰 미러링은 두 경로 모두에 이미 동일하게 적용되어 있음)
                 let unionBoxes: [CGRect]
                 if let unionBox = unionBoundingBox(from: maskedPixelBuffer) {
-                    let correctedBox: CGRect
-                    if isFront {
-                        // 좌우 반전
-                        correctedBox = CGRect(
-                            x: 1 - unionBox.origin.x - unionBox.size.width,
-                            y: unionBox.origin.y,
-                            width: unionBox.size.width,
-                            height: unionBox.size.height
-                        )
-                    } else {
-                        correctedBox = unionBox
-                    }
-                    unionBoxes = [correctedBox]
+                    unionBoxes = [unionBox]
                 } else {
                     unionBoxes = []
                 }

--- a/Chalkak/Data/Model/BoundingBoxInfo.swift
+++ b/Chalkak/Data/Model/BoundingBoxInfo.swift
@@ -11,8 +11,19 @@ import Foundation
 struct BoundingBoxInfo: Codable {
     /// Bounding Box 의 위치 값
     var origin: PointWrapper
-    /// Bounding Box 의 크기 값
+    /// Bounding Box 의 너비 값
     var scale: CGFloat
+    /// Bounding Box 의 높이 값. 기존 데이터는 scale을 높이 fallback으로 사용합니다.
+    var height: CGFloat?
+
+    var cgRect: CGRect {
+        CGRect(
+            x: origin.x,
+            y: origin.y,
+            width: scale,
+            height: height ?? scale
+        )
+    }
 }
 
 /// CGPoint를 SwiftData에 저장할 수 없어 CGFloat 형태로 변환하는 Wrapper 구조체입니다.

--- a/Chalkak/Presentation/Guide/Distance/BoundingBoxViewModel.swift
+++ b/Chalkak/Presentation/Guide/Distance/BoundingBoxViewModel.swift
@@ -61,14 +61,7 @@ class BoundingBoxViewModel {
 
     /// 기준 설정
     func setReference(from guide: Guide) {
-        let referenceBoxes: [CGRect] = guide.boundingBoxes.map { boxInfo in
-            CGRect(
-                x: boxInfo.origin.x,
-                y: boxInfo.origin.y,
-                width: boxInfo.scale,
-                height: boxInfo.scale // or use separate width/height if needed
-            )
-        }
+        let referenceBoxes = guide.boundingBoxes.map(\.cgRect)
 
         referenceBoundingBoxes = referenceBoxes
         isSettingReference = true
@@ -106,11 +99,11 @@ class BoundingBoxViewModel {
         let liveArea = live.width * live.height
         let ratio = liveArea / refArea
 
-        let xDiff = abs(live.minX - ref.minX)
-        let yDiff = abs(live.minY - ref.minY)
+        let xDiff = abs(live.midX - ref.midX)
+        let yDiff = abs(live.midY - ref.midY)
 
         let areaOk = (0.7 ... 1.3).contains(ratio)
-        let positionOk = (xDiff < 0.05 && yDiff < 0.05)
+        let positionOk = (xDiff < 0.08 && yDiff < 0.08)
 
         return areaOk && positionOk
     }

--- a/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayViewModel.swift
@@ -112,7 +112,11 @@ final class OverlayViewModel: ObservableObject {
            let outlineImage = overlayManager.outlineImage
         {
             let boundingBoxInfos = overlayManager.boundingBoxes.map { box in
-                BoundingBoxInfo(origin: PointWrapper(box.origin), scale: box.width)
+                BoundingBoxInfo(
+                    origin: PointWrapper(box.origin),
+                    scale: box.width,
+                    height: box.height
+                )
             }
             project.guide.boundingBoxes = boundingBoxInfos
             project.guide.outlineImageData = outlineImage.pngData() ?? Data()
@@ -195,7 +199,8 @@ final class OverlayViewModel: ObservableObject {
         let boundingBoxInfos = overlayManager.boundingBoxes.map { box in
             BoundingBoxInfo(
                 origin: PointWrapper(box.origin),
-                scale: box.width
+                scale: box.width,
+                height: box.height
             )
         }
 

--- a/ChalkakTests/ChalkakTests.swift
+++ b/ChalkakTests/ChalkakTests.swift
@@ -6,12 +6,42 @@
 //
 
 import Testing
+import Foundation
 @testable import Chalkak
 
 struct ChalkakTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func boundingBoxInfoPreservesNonSquareHeight() {
+        let box = BoundingBoxInfo(
+            origin: PointWrapper(CGPoint(x: 0.2, y: 0.1)),
+            scale: 0.25,
+            height: 0.75
+        )
+
+        #expect(box.cgRect == CGRect(x: 0.2, y: 0.1, width: 0.25, height: 0.75))
+    }
+
+    @Test func boundingBoxInfoFallsBackToScaleForLegacyBoxes() {
+        let legacyBox = BoundingBoxInfo(
+            origin: PointWrapper(CGPoint(x: 0.2, y: 0.1)),
+            scale: 0.25
+        )
+
+        #expect(legacyBox.cgRect == CGRect(x: 0.2, y: 0.1, width: 0.25, height: 0.25))
+    }
+
+    @Test func compareUsesCenterSoSmallOriginJitterStillAligns() {
+        let viewModel = BoundingBoxViewModel()
+        viewModel.referenceBoundingBoxes = [
+            CGRect(x: 0.20, y: 0.10, width: 0.25, height: 0.75)
+        ]
+        viewModel.liveBoundingBoxes = [
+            CGRect(x: 0.145, y: 0.205, width: 0.36, height: 0.54)
+        ]
+
+        viewModel.compare()
+
+        #expect(viewModel.isAligned)
     }
 
 }


### PR DESCRIPTION
## 🔖 해결한 이슈
- Resolved: #106

## ✨ PR Content
거리 피드백(가이드에 맞춰 서면 색으로 알려주는 기능)이 후면에서는 부정확하고, 전면에선 아예 안 뜨던 문제를 개선했습니다. 

**1. 박스 비교 방식 개선 → 피드백 안정성 ↑**
- 인식 박스를 정사각형이 아니라 **실제 모양(가로·세로)** 그대로 저장
- 위치 비교를 좌상단 → **중앙 기준**으로 바꾸고 오차 허용치를 살짝 넉넉하게 (0.05 → 0.08)
- 결과: 조금 흔들려도 피드백이 안정적으로 뜸 (주로 후면 개선)

**2. 전면 카메라 좌표계 정렬 → 전면 피드백 복구**
- 기억한 위치(가이드)와 현재 위치(실시간) 기준이 전면에서만 좌우·상하로 뒤집혀있던 걸 수정했습니다.
- `OverlayManager` 좌우반전 중복 보정 제거 + `CameraManager` 인식용 영상 미러링 끔
- 결과: 후면처럼 전면도 정상 동작 (후면/녹화 영상엔 영향 없음)

## 📍 PR Point
- 카메라를 활용하는 부분이다보니, 환경에따라 다를 수 있습니다. 건의 해주시면 개선하겠습니다. 