### PR TITLE
✨ [Feat] 온보딩 플로우에 촬영 체험 과정 추가

### DIFF
--- a/Chalkak.xcodeproj/project.pbxproj
+++ b/Chalkak.xcodeproj/project.pbxproj
@@ -8,9 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		0D5512EC2E432177001FA7F9 /* PermissionCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5512EB2E432174001FA7F9 /* PermissionCheckView.swift */; };
-		A1B2C3D42FD0000100000001 /* OnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FD0000100000003 /* OnboardingStep.swift */; };
-		A1B2C3D42FD0000100000002 /* OnboardingFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FD0000100000004 /* OnboardingFlowController.swift */; };
-		B6D100002FD53A0000010001 /* OnboardingNotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D100002FD53A0000010002 /* OnboardingNotificationScheduler.swift */; };
 		0D5512F92E541723001FA7F9 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5512F82E541718001FA7F9 /* OnboardingView.swift */; };
 		0D5512FB2E541762001FA7F9 /* OnboardingSubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5512FA2E541750001FA7F9 /* OnboardingSubView.swift */; };
 		7D17CABC2EEFE93C00C26529 /* StartProjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D17CABB2EEFE93C00C26529 /* StartProjectView.swift */; };
@@ -38,6 +35,12 @@
 		992EE80B2E36BC9F0079AFBF /* AVMutableComposition + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE80A2E36BC980079AFBF /* AVMutableComposition + Ext.swift */; };
 		992EE80D2E36C8C90079AFBF /* PlayTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE80C2E36C8C60079AFBF /* PlayTimeView.swift */; };
 		992EE8172E36CFE70079AFBF /* ProjectTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 992EE8162E36CFB00079AFBF /* ProjectTimelineView.swift */; };
+		9936E4E42FF0C8F3006CD9F8 /* OnboardingFirstShootExperienceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9936E4E32FF0C8E4006CD9F8 /* OnboardingFirstShootExperienceView.swift */; };
+		9936E4E62FF0C90D006CD9F8 /* OnboardingExperienceRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9936E4E52FF0C906006CD9F8 /* OnboardingExperienceRoute.swift */; };
+		9936E4E82FF0C929006CD9F8 /* OnboardingFollowUpShootExperienceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9936E4E72FF0C91E006CD9F8 /* OnboardingFollowUpShootExperienceView.swift */; };
+		9936E4EA2FF0F82D006CD9F8 /* OnboardingGuideCameraPromptOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9936E4E92FF0F821006CD9F8 /* OnboardingGuideCameraPromptOverlay.swift */; };
+		9936E4EE2FF116C4006CD9F8 /* OnboardingEditorTooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9936E4ED2FF116BC006CD9F8 /* OnboardingEditorTooltip.swift */; };
+		9936E4F02FF116EB006CD9F8 /* Shape + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9936E4EF2FF116D9006CD9F8 /* Shape + Ext.swift */; };
 		993A1F502E267E0C0059B70A /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 993A1F4A2E267E0C0059B70A /* Preview Assets.xcassets */; };
 		993A1F512E267E0C0059B70A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 993A1F4C2E267E0C0059B70A /* Assets.xcassets */; };
 		993A1F522E267E0C0059B70A /* sample-video.mov in Resources */ = {isa = PBXBuildFile; fileRef = 993A1F4D2E267E0C0059B70A /* sample-video.mov */; };
@@ -106,6 +109,8 @@
 		99E6F0142E90DC03002ED9C2 /* SchemaV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E6F0132E90DBF9002ED9C2 /* SchemaV1.swift */; };
 		99E6F0162E90DCBB002ED9C2 /* AppTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E6F0152E90DCB4002ED9C2 /* AppTypes.swift */; };
 		99E6F01A2E90EDA9002ED9C2 /* SchemaV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E6F0192E90EDA5002ED9C2 /* SchemaV2.swift */; };
+		A1B2C3D42FD0000100000001 /* OnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FD0000100000003 /* OnboardingStep.swift */; };
+		A1B2C3D42FD0000100000002 /* OnboardingFlowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42FD0000100000004 /* OnboardingFlowController.swift */; };
 		B60564A52E3A767F00AACABE /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60564A42E3A767F00AACABE /* FileManager+Extensions.swift */; };
 		B60DC5F12E38A621001D8327 /* SnappieProgressAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60DC5F02E38A621001D8327 /* SnappieProgressAlert.swift */; };
 		B64788642E3323C40091A067 /* RecordButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64788632E3323C10091A067 /* RecordButton.swift */; };
@@ -119,6 +124,7 @@
 		B6A592732E37CB4900D3DF6A /* CommonAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A592722E37CB4400D3DF6A /* CommonAlert.swift */; };
 		B6A592762E38470D00D3DF6A /* SnappieAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A592742E38470D00D3DF6A /* SnappieAlert.swift */; };
 		B6AB62AE2E2E8DBE00207590 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B6D100002FD53A0000010001 /* OnboardingNotificationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D100002FD53A0000010002 /* OnboardingNotificationScheduler.swift */; };
 		C52566D42FB3911E0026EA67 /* ExportMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52566D32FB3911E0026EA67 /* ExportMode.swift */; };
 		C54ABC032EF9080400A9EC1E /* PlayheadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54ABC022EF9080400A9EC1E /* PlayheadView.swift */; };
 		C54ABC0F2F01A4C000A9EC1E /* ClipToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54ABC0E2F01A4C000A9EC1E /* ClipToolbarView.swift */; };
@@ -179,9 +185,6 @@
 
 /* Begin PBXFileReference section */
 		0D5512EB2E432174001FA7F9 /* PermissionCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCheckView.swift; sourceTree = "<group>"; };
-		A1B2C3D42FD0000100000003 /* OnboardingStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStep.swift; sourceTree = "<group>"; };
-		A1B2C3D42FD0000100000004 /* OnboardingFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowController.swift; sourceTree = "<group>"; };
-		B6D100002FD53A0000010002 /* OnboardingNotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNotificationScheduler.swift; sourceTree = "<group>"; };
 		0D5512F82E541718001FA7F9 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		0D5512FA2E541750001FA7F9 /* OnboardingSubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSubView.swift; sourceTree = "<group>"; };
 		7D17CABB2EEFE93C00C26529 /* StartProjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartProjectView.swift; sourceTree = "<group>"; };
@@ -209,6 +212,12 @@
 		992EE80A2E36BC980079AFBF /* AVMutableComposition + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVMutableComposition + Ext.swift"; sourceTree = "<group>"; };
 		992EE80C2E36C8C60079AFBF /* PlayTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayTimeView.swift; sourceTree = "<group>"; };
 		992EE8162E36CFB00079AFBF /* ProjectTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTimelineView.swift; sourceTree = "<group>"; };
+		9936E4E32FF0C8E4006CD9F8 /* OnboardingFirstShootExperienceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFirstShootExperienceView.swift; sourceTree = "<group>"; };
+		9936E4E52FF0C906006CD9F8 /* OnboardingExperienceRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingExperienceRoute.swift; sourceTree = "<group>"; };
+		9936E4E72FF0C91E006CD9F8 /* OnboardingFollowUpShootExperienceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFollowUpShootExperienceView.swift; sourceTree = "<group>"; };
+		9936E4E92FF0F821006CD9F8 /* OnboardingGuideCameraPromptOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingGuideCameraPromptOverlay.swift; sourceTree = "<group>"; };
+		9936E4ED2FF116BC006CD9F8 /* OnboardingEditorTooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingEditorTooltip.swift; sourceTree = "<group>"; };
+		9936E4EF2FF116D9006CD9F8 /* Shape + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Shape + Ext.swift"; sourceTree = "<group>"; };
 		993A1CC62E2049D50059B70A /* Chalkak.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chalkak.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		993A1CD62E2049D60059B70A /* ChalkakTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChalkakTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		993A1CE02E2049D60059B70A /* ChalkakUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChalkakUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -274,6 +283,8 @@
 		99E6F0132E90DBF9002ED9C2 /* SchemaV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV1.swift; sourceTree = "<group>"; };
 		99E6F0152E90DCB4002ED9C2 /* AppTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTypes.swift; sourceTree = "<group>"; };
 		99E6F0192E90EDA5002ED9C2 /* SchemaV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaV2.swift; sourceTree = "<group>"; };
+		A1B2C3D42FD0000100000003 /* OnboardingStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStep.swift; sourceTree = "<group>"; };
+		A1B2C3D42FD0000100000004 /* OnboardingFlowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingFlowController.swift; sourceTree = "<group>"; };
 		B60564A42E3A767F00AACABE /* FileManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
 		B60DC5F02E38A621001D8327 /* SnappieProgressAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnappieProgressAlert.swift; sourceTree = "<group>"; };
 		B64788632E3323C10091A067 /* RecordButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordButton.swift; sourceTree = "<group>"; };
@@ -286,6 +297,7 @@
 		B6A592612E37B49000D3DF6A /* ZoomButtonGestureModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomButtonGestureModifier.swift; sourceTree = "<group>"; };
 		B6A592722E37CB4400D3DF6A /* CommonAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonAlert.swift; sourceTree = "<group>"; };
 		B6A592742E38470D00D3DF6A /* SnappieAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnappieAlert.swift; sourceTree = "<group>"; };
+		B6D100002FD53A0000010002 /* OnboardingNotificationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNotificationScheduler.swift; sourceTree = "<group>"; };
 		C52566D32FB3911E0026EA67 /* ExportMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportMode.swift; sourceTree = "<group>"; };
 		C54ABC022EF9080400A9EC1E /* PlayheadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayheadView.swift; sourceTree = "<group>"; };
 		C54ABC0E2F01A4C000A9EC1E /* ClipToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipToolbarView.swift; sourceTree = "<group>"; };
@@ -368,6 +380,7 @@
 		0D5512F02E4B2D36001FA7F9 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				9936E4E52FF0C906006CD9F8 /* OnboardingExperienceRoute.swift */,
 				A1B2C3D42FD0000100000003 /* OnboardingStep.swift */,
 				A1B2C3D42FD0000100000004 /* OnboardingFlowController.swift */,
 				B6D100002FD53A0000010002 /* OnboardingNotificationScheduler.swift */,
@@ -380,6 +393,10 @@
 		0D5512F52E5415C9001FA7F9 /* SubViews */ = {
 			isa = PBXGroup;
 			children = (
+				9936E4ED2FF116BC006CD9F8 /* OnboardingEditorTooltip.swift */,
+				9936E4E92FF0F821006CD9F8 /* OnboardingGuideCameraPromptOverlay.swift */,
+				9936E4E72FF0C91E006CD9F8 /* OnboardingFollowUpShootExperienceView.swift */,
+				9936E4E32FF0C8E4006CD9F8 /* OnboardingFirstShootExperienceView.swift */,
 				0D5512FA2E541750001FA7F9 /* OnboardingSubView.swift */,
 			);
 			path = SubViews;
@@ -763,6 +780,7 @@
 		993A21802E26AB9C0059B70A /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				9936E4EF2FF116D9006CD9F8 /* Shape + Ext.swift */,
 				7DD82CC42EFFB01A00AD8DFC /* TimeInterval+Extension.swift */,
 				992EE80A2E36BC980079AFBF /* AVMutableComposition + Ext.swift */,
 				99C93A3C2E2B998100F42541 /* UIImage + Ext.swift */,
@@ -1139,6 +1157,7 @@
 				B68A46CF2E38A25D0062F04E /* SnappieProgress.swift in Sources */,
 				C5C12EB62E3380D100C4DC6D /* NavigationEnums.swift in Sources */,
 				993A1F592E267E0C0059B70A /* OverlayManager.swift in Sources */,
+				9936E4E42FF0C8F3006CD9F8 /* OnboardingFirstShootExperienceView.swift in Sources */,
 				C54ABC0F2F01A4C000A9EC1E /* ClipToolbarView.swift in Sources */,
 				C5C12EAC2E325A3B00C4DC6D /* IconButtonStyler.swift in Sources */,
 				7D17CABC2EEFE93C00C26529 /* StartProjectView.swift in Sources */,
@@ -1182,15 +1201,19 @@
 				C5C12EB12E33684F00C4DC6D /* SnappieNavigationBar.swift in Sources */,
 				7D60F6492F0D141800621874 /* SchemaV3.swift in Sources */,
 				C5FB3EBD2E26AA0700A4C1BE /* VideoMerger.swift in Sources */,
+				9936E4F02FF116EB006CD9F8 /* Shape + Ext.swift in Sources */,
 				994EFAE42F19330C0029AAE3 /* ClipPlayheadView.swift in Sources */,
 				993A1F672E267E0C0059B70A /* CameraBottomControlView.swift in Sources */,
 				C5FB3EC12E28F11100A4C1BE /* PhotoLibrarySaver.swift in Sources */,
+				9936E4E82FF0C929006CD9F8 /* OnboardingFollowUpShootExperienceView.swift in Sources */,
+				9936E4EA2FF0F82D006CD9F8 /* OnboardingGuideCameraPromptOverlay.swift in Sources */,
 				7DD82CC02EFEC2A400AD8DFC /* GuideFrameSelectorView.swift in Sources */,
 				B60DC5F12E38A621001D8327 /* SnappieProgressAlert.swift in Sources */,
 				C5C12EA82E3227D100C4DC6D /* ButtonGlass.swift in Sources */,
 				B6AB62AE2E2E8DBE00207590 /* (null) in Sources */,
 				B64788662E3324130091A067 /* TorchMode.swift in Sources */,
 				99C93A0E2E27BB0700F42541 /* Path.swift in Sources */,
+				9936E4EE2FF116C4006CD9F8 /* OnboardingEditorTooltip.swift in Sources */,
 				C5F7B69C2E2EB25F0066B59C /* Icon.swift in Sources */,
 				C5F7B69F2E2EB7AB0066B59C /* IconView.swift in Sources */,
 				993A1F682E267E0C0059B70A /* CameraDefaultTopControlView.swift in Sources */,
@@ -1241,6 +1264,7 @@
 				993A1F7A2E267E0C0059B70A /* ProjectPreviewView.swift in Sources */,
 				7DD82CBB2EFEA2E400AD8DFC /* GuideSelectView.swift in Sources */,
 				992EE7C22E32ACBA0079AFBF /* ProjectEditView.swift in Sources */,
+				9936E4E62FF0C90D006CD9F8 /* OnboardingExperienceRoute.swift in Sources */,
 				A1B2C3D42FD0000100000001 /* OnboardingStep.swift in Sources */,
 				A1B2C3D42FD0000100000002 /* OnboardingFlowController.swift in Sources */,
 				B6D100002FD53A0000010001 /* OnboardingNotificationScheduler.swift in Sources */,

--- a/Chalkak/App/ChalkakApp.swift
+++ b/Chalkak/App/ChalkakApp.swift
@@ -105,6 +105,11 @@ struct ChalkakApp: App {
                 OnboardingView(onComplete: {
                     hasCompletedOnboarding = true
                 })
+                .environmentObject(coordinator)
+                .environment(permissionManager)
+                .sheet(isPresented: $permissionManager.showPermissionSheet) {
+                    CameraPermissionSheet(permissionManager: permissionManager)
+                }
             }
         }
         .modelContainer(sharedContainer)

--- a/Chalkak/Common/DesignSystem/SnappieColor.swift
+++ b/Chalkak/Common/DesignSystem/SnappieColor.swift
@@ -37,6 +37,8 @@ enum SnappieColor {
     static let redRecording: Color = Color("red-recording")
     static let gradientFillNormal = Gradient(colors: [ Color("matcha-200").opacity(0.2), Color("deep-green-600").opacity(0.15)])
     
+    static let tooltipBackground: Color = Color("matcha-300")
+    
     // MARK: - Foundation 색상
     static let matcha50: Color = Color("matcha-50")
     

--- a/Chalkak/Common/Extension/Shape + Ext.swift
+++ b/Chalkak/Common/Extension/Shape + Ext.swift
@@ -1,0 +1,19 @@
+//
+//  Shape + Ext.swift
+//  Chalkak
+//
+//  Created by 배현진 on 6/28/26.
+//
+
+import SwiftUI
+
+struct TooltipTriangleShape: Shape {
+    func path(in rect: CGRect) -> SwiftUI.Path {
+        var path = SwiftUI.Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}

--- a/Chalkak/Presentation/Camera/CameraView.swift
+++ b/Chalkak/Presentation/Camera/CameraView.swift
@@ -11,7 +11,9 @@ import SwiftUI
 struct CameraView: View {
     let shootState: ShootState
     let isAligned: Bool
-
+    let onboardingVideoSaved: ((URL, CameraSetting, CameraManager, [TimeStampedTilt]) -> Void)?
+    let onboardingExit: (() -> Void)?
+    
     private var guide: Guide? {
         switch shootState {
         case .firstShoot:
@@ -21,7 +23,8 @@ struct CameraView: View {
         }
     }
 
-    @State var viewModel = CameraViewModel()
+    @State var viewModel: CameraViewModel
+    
     @EnvironmentObject private var coordinator: Coordinator
     @Environment(PermissionManager.self) private var permissionManager
 
@@ -30,6 +33,20 @@ struct CameraView: View {
     @State private var feedbackOpacity: Double = 0
     @State private var fadeOutTask: Task<Void, Never>?
 
+    init(
+        shootState: ShootState,
+        isAligned: Bool,
+        viewModel: CameraViewModel = CameraViewModel(),
+        onboardingVideoSaved: ((URL, CameraSetting, CameraManager, [TimeStampedTilt]) -> Void)? = nil,
+        onboardingExit: (() -> Void)? = nil
+    ) {
+        self.shootState = shootState
+        self.isAligned = isAligned
+        self._viewModel = State(wrappedValue: viewModel)
+        self.onboardingVideoSaved = onboardingVideoSaved
+        self.onboardingExit = onboardingExit
+    }
+    
     var body: some View {
         ZStack {
             if isAligned {
@@ -85,6 +102,12 @@ struct CameraView: View {
                     size: .large,
                     isActive: true
                 )) {
+                    if let onboardingExit {
+                        viewModel.stopCamera()
+                        onboardingExit()
+                        return
+                    }
+                    
                     viewModel.exitCamera()
                     Analytics.logEvent("exitCameraAlertTapped", parameters: nil)
                 }
@@ -126,26 +149,42 @@ struct CameraView: View {
             }
         }
         .onReceive(viewModel.videoSavedPublisher) { url in
+            let cameraSetting = CameraSetting(
+                zoomScale: viewModel.zoomScale,
+                isGridEnabled: viewModel.isGrid,
+                isFrontPosition: viewModel.isUsingFrontCamera,
+                timerSecond: viewModel.selectedTimerDuration.rawValue
+            )
+
+            if let onboardingVideoSaved {
+                onboardingVideoSaved(
+                    url,
+                    cameraSetting,
+                    viewModel.model,
+                    viewModel.timeStampedTiltList
+                )
+                return
+            }
+
             self.clipUrl = url
             viewModel.saveCameraSettings()
 
             coordinator.push(.clipEdit(
                 clipURL: url,
                 state: shootState,
-                cameraSetting: CameraSetting(
-                    zoomScale: viewModel.zoomScale,
-                    isGridEnabled: viewModel.isGrid,
-                    isFrontPosition: viewModel.isUsingFrontCamera,
-                    timerSecond: viewModel.selectedTimerDuration.rawValue
-                ),
+                cameraSetting: cameraSetting,
                 cameraManager: viewModel.model,
                 TimeStampedTiltList: viewModel.timeStampedTiltList
-            )
-            )
+            ))
         }
         .onAppear {
             viewModel.coordinator = coordinator
-            permissionManager.reevaluateAndPresentIfNeeded()
+            
+            if onboardingVideoSaved != nil {
+                permissionManager.requestAndCheckPermissions()
+            } else {
+                permissionManager.reevaluateAndPresentIfNeeded()
+            }
 
             if permissionManager.permissionState == .both {
                 viewModel.startCamera()

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
@@ -24,6 +24,7 @@ struct GuideSelectView: View {
     @State private var viewModel: GuideSelectViewModel
     @EnvironmentObject private var coordinator: Coordinator
     @State private var isDragging = false
+    @State private var showsOnboardingTooltip = true
 
     private var overlayImage: UIImage? {
         switch shootState {
@@ -34,7 +35,11 @@ struct GuideSelectView: View {
             return guide.outlineImage
         }
     }
-
+    
+    private var isOnboardingMode: Bool {
+        onboardingCompletion != nil
+    }
+    
     init(
         clip: Clip,
         shootState: ShootState,
@@ -125,25 +130,45 @@ struct GuideSelectView: View {
                             .padding(.trailing, 24)
                     }
                     // 하단 썸네일 부분
-                    GuideFrameSelectorView(
-                        state: FrameSelectorState(
-                            thumbnails: viewModel.thumbnails,
-                            duration: viewModel.duration,
-                            startPoint: viewModel.startPoint,
-                            thumbnailUnitWidth: { viewModel.thumbnailUnitWidth(for: $0) },
-                            startX: { viewModel.startX(thumbnailLineWidth: $0, handleWidth: $1) }
-                        ),
-                        actions: FrameSelectorActions(
-                            pause: { viewModel.player.pause() },
-                            setNotPlaying: { viewModel.isPlaying = false },
-                            updateStart: { viewModel.updateStart($0) },
-                            seek: { viewModel.seek(to: $0) }
-                        ),
-                        isDragging: $isDragging
-                    )
+                    ZStack(alignment: .topLeading) {
+                        GuideFrameSelectorView(
+                            state: FrameSelectorState(
+                                thumbnails: viewModel.thumbnails,
+                                duration: viewModel.duration,
+                                startPoint: viewModel.startPoint,
+                                thumbnailUnitWidth: { viewModel.thumbnailUnitWidth(for: $0) },
+                                startX: { viewModel.startX(thumbnailLineWidth: $0, handleWidth: $1) }
+                            ),
+                            actions: FrameSelectorActions(
+                                pause: { viewModel.player.pause() },
+                                setNotPlaying: { viewModel.isPlaying = false },
+                                updateStart: { value in
+                                    dismissOnboardingTooltip()
+                                    viewModel.updateStart(value)
+                                },
+                                seek: { viewModel.seek(to: $0) }
+                            ),
+                            isDragging: $isDragging
+                        )
                         .padding(.horizontal, 26)
+
+                        if isOnboardingMode && showsOnboardingTooltip {
+                            OnboardingEditorTooltip(text: "어떤 장면을 가이드로 사용할까요?")
+                                .padding(.leading, 23)
+                                .offset(y: -50)
+                                .transition(.opacity)
+                                .zIndex(2)
+                                .allowsHitTesting(false)
+                        }
+                    }
                 }
             }
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    dismissOnboardingTooltip()
+                }
+            )
             .padding(.bottom, 14)
         }
         .navigationBarBackButtonHidden(true)
@@ -167,6 +192,14 @@ struct GuideSelectView: View {
                     viewModel.seek(to: clamped)
                 }
             }
+        }
+    }
+    
+    private func dismissOnboardingTooltip() {
+        guard showsOnboardingTooltip else { return }
+
+        withAnimation(.easeOut(duration: 0.35)) {
+            showsOnboardingTooltip = false
         }
     }
 }

--- a/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
+++ b/Chalkak/Presentation/Camera/GuideSelect/GuideSelectView.swift
@@ -18,6 +18,8 @@ struct GuideSelectView: View {
     let shootState: ShootState
     let cameraSetting: CameraSetting
     let cameraManager: CameraManager
+    let onboardingBack: (() -> Void)?
+    let onboardingCompletion: ((Double) -> Void)?
 
     @State private var viewModel: GuideSelectViewModel
     @EnvironmentObject private var coordinator: Coordinator
@@ -37,13 +39,17 @@ struct GuideSelectView: View {
         clip: Clip,
         shootState: ShootState,
         cameraSetting: CameraSetting,
-        cameraManager: CameraManager
+        cameraManager: CameraManager,
+        onboardingCompletion: ((Double) -> Void)? = nil,
+        onboardingBack: (() -> Void)? = nil
     ) {
         self.clip = clip
         self.shootState = shootState
         self.cameraSetting = cameraSetting
         self.cameraManager = cameraManager
-
+        self.onboardingCompletion = onboardingCompletion
+        self.onboardingBack = onboardingBack
+        
         _viewModel = State(wrappedValue: GuideSelectViewModel(clipURL: clip.videoURL))
     }
 
@@ -56,16 +62,21 @@ struct GuideSelectView: View {
                 SnappieNavigationBar(
                     navigationTitle: Text("가이드 선택"),
                     leftButtonType: .backward {
+                        if let onboardingBack {
+                            onboardingBack()
+                            return
+                        }
+                        
                         coordinator.popLast()
                     },
                     rightButtonType: .oneButton(
                         .init(label: "완료") {
-                            guard let previous = coordinator.previousPath else {
+                            let originalTimestamp = clip.startPoint + viewModel.startPoint
+
+                            if let onboardingCompletion {
+                                onboardingCompletion(originalTimestamp)
                                 return
                             }
-
-                            // 트리밍 시간을 원본시간으로 변환
-                            let originalTimestamp = clip.startPoint + viewModel.startPoint
 
                             coordinator.push(
                                 .overlay(

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -45,6 +45,9 @@ struct ClipEditView: View {
     let shootState: ShootState
     let cameraSetting: CameraSetting
     let cameraManager: CameraManager
+    let onboardingCompletion: ((Clip, CameraSetting, CameraManager) -> Void)?
+    let onboardingFinishShoot: (() -> Void)?
+    let onboardingBack: (() -> Void)?
 
     // 2. State & ObservedObject
     @State private var editViewModel: ClipEditViewModel
@@ -72,18 +75,24 @@ struct ClipEditView: View {
         cameraSetting: CameraSetting,
         cameraManager: CameraManager,
         timeStampedTiltList: [TimeStampedTilt],
-        clipID: String? = nil
+        clipID: String? = nil,
+        onboardingCompletion: ((Clip, CameraSetting, CameraManager) -> Void)? = nil,
+        onboardingFinishShoot: (() -> Void)? = nil,
+        onboardingBack: (() -> Void)? = nil
     ) {
         _editViewModel = State(wrappedValue: ClipEditViewModel(
             clipURL: clipURL,
             cameraSetting: cameraSetting,
             timeStampedTiltList: timeStampedTiltList,
             clipID: clipID
-        )
-        )
+        ))
+
         self.shootState = shootState
         self.cameraSetting = cameraSetting
         self.cameraManager = cameraManager
+        self.onboardingCompletion = onboardingCompletion
+        self.onboardingFinishShoot = onboardingFinishShoot
+        self.onboardingBack = onboardingBack
     }
 
     // 5. body
@@ -96,6 +105,11 @@ struct ClipEditView: View {
                 SnappieNavigationBar(
                     navigationTitle: Text("장면 다듬기"),
                     leftButtonType: .backward {
+                        if let onboardingBack {
+                            onboardingBack()
+                            return
+                        }
+                        
                         guard let previous = coordinator.previousPath else {
                             return
                         }
@@ -111,6 +125,25 @@ struct ClipEditView: View {
                     },
                     rightButtonType: .oneButton(
                         .init(label: "완료") {
+                            if onboardingCompletion != nil || onboardingFinishShoot != nil {
+                                switch shootState {
+                                case .firstShoot:
+                                    if let onboardingCompletion {
+                                        let clip = editViewModel.createClipData()
+                                        onboardingCompletion(
+                                            clip,
+                                            editViewModel.cameraSetting,
+                                            cameraManager
+                                        )
+                                    }
+
+                                case .followUpShoot, .appendShoot:
+                                    onboardingFinishShoot?()
+                                }
+
+                                return
+                            }
+
                             guard let previous = coordinator.previousPath else {
                                 return
                             }
@@ -119,6 +152,7 @@ struct ClipEditView: View {
                             case .projectEdit:
                                 editViewModel.updateClipInTempProject()
                                 coordinator.popLast()
+
                             default:
                                 switch shootState {
                                 case .firstShoot:
@@ -130,8 +164,10 @@ struct ClipEditView: View {
                                             cameraManager: cameraManager
                                         )
                                     )
+
                                 case .followUpShoot:
                                     showActionSheet = true
+
                                 case .appendShoot:
                                     let newClip = editViewModel.createClipData()
 

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -138,6 +138,7 @@ struct ClipEditView: View {
                                     }
 
                                 case .followUpShoot, .appendShoot:
+                                    editViewModel.appendClipToCurrentProject()
                                     onboardingFinishShoot?()
                                 }
 

--- a/Chalkak/Presentation/ClipEdit/ClipEditView.swift
+++ b/Chalkak/Presentation/ClipEdit/ClipEditView.swift
@@ -57,6 +57,7 @@ struct ClipEditView: View {
     @State private var autoPlayEnabled = true
     @State private var showActionSheet = false
     @State private var showRetakeAlert = false
+    @State private var showsOnboardingTooltip = true
 
     // 3. 계산 프로퍼티
     private var guide: Guide? {
@@ -68,6 +69,10 @@ struct ClipEditView: View {
         }
     }
 
+    private var shouldShowOnboardingTooltip: Bool {
+        onboardingCompletion != nil
+    }
+    
     // 4. init
     init(
         clipURL: URL,
@@ -196,9 +201,32 @@ struct ClipEditView: View {
                     )
                 )
 
-                TrimmingControlView(editViewModel: editViewModel, isDragging: $isDragging)
+                ZStack(alignment: .topLeading) {
+                    TrimmingControlView(
+                        editViewModel: editViewModel,
+                        isDragging: $isDragging,
+                        onInteractionStarted: {
+                            dismissOnboardingTooltip()
+                        }
+                    )
+
+                    if shouldShowOnboardingTooltip && showsOnboardingTooltip {
+                        OnboardingEditorTooltip(text: "필요 없는 부분은 잘라낼 수 있어요")
+                            .padding(.leading, 23)
+                            .offset(y: -20)
+                            .transition(.opacity)
+                            .zIndex(2)
+                            .allowsHitTesting(false)
+                    }
+                }
             }
             .padding(.bottom, 14)
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                TapGesture().onEnded {
+                    dismissOnboardingTooltip()
+                }
+            )
         }
         .navigationBarBackButtonHidden(true)
         .confirmationDialog(
@@ -247,6 +275,14 @@ struct ClipEditView: View {
         }
         .onDisappear {
             editViewModel.cleanup()
+        }
+    }
+    
+    private func dismissOnboardingTooltip() {
+        guard showsOnboardingTooltip else { return }
+
+        withAnimation(.easeOut(duration: 0.35)) {
+            showsOnboardingTooltip = false
         }
     }
 }

--- a/Chalkak/Presentation/ClipEdit/SubViews/TrimmingControlView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/TrimmingControlView.swift
@@ -23,7 +23,18 @@ import SwiftUI
 struct TrimmingControlView: View {
     var editViewModel: ClipEditViewModel
     @Binding var isDragging: Bool
+    let onInteractionStarted: (() -> Void)?
 
+    init(
+        editViewModel: ClipEditViewModel,
+        isDragging: Binding<Bool>,
+        onInteractionStarted: (() -> Void)? = nil
+    ) {
+        self.editViewModel = editViewModel
+        self._isDragging = isDragging
+        self.onInteractionStarted = onInteractionStarted
+    }
+    
     var body: some View {
         VStack(alignment: .center, spacing: 8, content: {
             Divider()
@@ -31,8 +42,12 @@ struct TrimmingControlView: View {
             
             TrimmingTimeDisplayView(editViewModel: editViewModel)
             
-            TrimmingLineView(editViewModel: editViewModel, isDragging: $isDragging)
-                .padding(.horizontal, 26)
+            TrimmingLineView(
+                editViewModel: editViewModel,
+                isDragging: $isDragging,
+                onInteractionStarted: onInteractionStarted
+            )
+            .padding(.horizontal, 26)
             
         })
     }

--- a/Chalkak/Presentation/ClipEdit/SubViews/TrimmingLineView.swift
+++ b/Chalkak/Presentation/ClipEdit/SubViews/TrimmingLineView.swift
@@ -27,7 +27,18 @@ import SwiftUI
 struct TrimmingLineView: View {
     var editViewModel: ClipEditViewModel
     @Binding var isDragging: Bool
-
+    let onInteractionStarted: (() -> Void)?
+    
+    init(
+        editViewModel: ClipEditViewModel,
+        isDragging: Binding<Bool>,
+        onInteractionStarted: (() -> Void)? = nil
+    ) {
+        self.editViewModel = editViewModel
+        self._isDragging = isDragging
+        self.onInteractionStarted = onInteractionStarted
+    }
+    
     var body: some View {
         /// 내부 상수 선언
         let totalWidth: CGFloat = TimelineConstants.totalWidth
@@ -95,6 +106,8 @@ struct TrimmingLineView: View {
                 .gesture(
                     DragGesture()
                         .onChanged { gesture in
+                            onInteractionStarted?()
+                            
                             isDragging = true
                             editViewModel.player.pause()
                             editViewModel.isPlaying = false
@@ -116,6 +129,8 @@ struct TrimmingLineView: View {
                 .gesture(
                     DragGesture()
                         .onChanged { gesture in
+                            onInteractionStarted?()
+                            
                             isDragging = true
                             editViewModel.player.pause()
                             editViewModel.isPlaying = false
@@ -143,6 +158,8 @@ struct TrimmingLineView: View {
                 .gesture(
                     DragGesture()
                         .onChanged { gesture in
+                            onInteractionStarted?()
+                            
                             isDragging = true
                             editViewModel.player.pause()
                             editViewModel.isPlaying = false
@@ -172,6 +189,8 @@ struct TrimmingLineView: View {
             // 드래그 제스처
             DragGesture()
                 .onChanged { gesture in
+                    onInteractionStarted?()
+                    
                     isDragging = true
                     editViewModel.player.pause()
                     editViewModel.isPlaying = false

--- a/Chalkak/Presentation/Guide/Distance/BoundingBoxView.swift
+++ b/Chalkak/Presentation/Guide/Distance/BoundingBoxView.swift
@@ -24,8 +24,5 @@ struct BoundingBoxView: View {
                 GuideCameraView(guide: guide, shootState: shootState)
             }
         }
-        .onAppear {
-            permissionManager.reevaluateAndPresentIfNeeded()
-        }
     }
 }

--- a/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/FirstShootCameraView.swift
@@ -8,12 +8,29 @@
 import SwiftUI
 
 struct FirstShootCameraView: View {
+    let onboardingVideoSaved: ((URL, CameraSetting, CameraManager, [TimeStampedTilt]) -> Void)?
+    let onboardingExit: (() -> Void)?
+    
     @State private var viewModel = BoundingBoxViewModel()
     @State private var cameraViewModel = CameraViewModel()
-
+    
+    init(
+        onboardingVideoSaved: ((URL, CameraSetting, CameraManager, [TimeStampedTilt]) -> Void)? = nil,
+        onboardingExit: (() -> Void)? = nil
+    ) {
+        self.onboardingVideoSaved = onboardingVideoSaved
+        self.onboardingExit = onboardingExit
+    }
+    
     var body: some View {
         ZStack {
-            CameraView(shootState: .firstShoot, isAligned: false, viewModel: cameraViewModel)
+            CameraView(
+                shootState: .firstShoot,
+                isAligned: false,
+                viewModel: cameraViewModel,
+                onboardingVideoSaved: onboardingVideoSaved,
+                onboardingExit: onboardingExit
+            )
         }
         .onAppear() {
             viewModel.deleteUserDefault()

--- a/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
+++ b/Chalkak/Presentation/Guide/Distance/SubViews/GuideCameraView.swift
@@ -10,13 +10,22 @@ import SwiftUI
 struct GuideCameraView: View {
     let guide: Guide?
     let shootState: ShootState
+    let onboardingVideoSaved: ((URL, CameraSetting, CameraManager, [TimeStampedTilt]) -> Void)?
+    let onboardingExit: (() -> Void)?
     
     @State private var viewModel = BoundingBoxViewModel()
     @State private var cameraViewModel = CameraViewModel()
 
-    init(guide: Guide?, shootState: ShootState) {
+    init(
+        guide: Guide?,
+        shootState: ShootState,
+        onboardingVideoSaved: ((URL, CameraSetting, CameraManager, [TimeStampedTilt]) -> Void)? = nil,
+        onboardingExit: (() -> Void)? = nil
+    ) {
         self.guide = guide
         self.shootState = shootState
+        self.onboardingVideoSaved = onboardingVideoSaved
+        self.onboardingExit = onboardingExit
 
         let cameraVM = CameraViewModel()
         self._cameraViewModel = State(wrappedValue: cameraVM)
@@ -30,12 +39,18 @@ struct GuideCameraView: View {
 
     var body: some View {        
         ZStack {
-            CameraView(shootState: shootState, isAligned: viewModel.isAligned, viewModel: cameraViewModel)
-                .onAppear {
-                    cameraViewModel.setBoundingBoxUpdateHandler { bboxes in
-                        viewModel.liveBoundingBoxes = bboxes
-                    }
+            CameraView(
+                shootState: shootState,
+                isAligned: viewModel.isAligned,
+                viewModel: cameraViewModel,
+                onboardingVideoSaved: onboardingVideoSaved,
+                onboardingExit: onboardingExit
+            )
+            .onAppear {
+                cameraViewModel.setBoundingBoxUpdateHandler { bboxes in
+                    viewModel.liveBoundingBoxes = bboxes
                 }
+            }
 
             if let guide = guide, let outline = guide.outlineImage {
                 Image(uiImage: outline)

--- a/Chalkak/Presentation/Guide/Overlay/OverlayView.swift
+++ b/Chalkak/Presentation/Guide/Overlay/OverlayView.swift
@@ -32,6 +32,7 @@ struct OverlayView: View {
     // 1. Input properties
     let clip: Clip
     let cameraSetting: CameraSetting
+    let onboardingCompletion: ((Guide) -> Void)?
 
     // 2. State & ObservedObject
     @StateObject var overlayViewModel: OverlayViewModel
@@ -45,11 +46,20 @@ struct OverlayView: View {
         clip: Clip,
         cameraSetting: CameraSetting,
         cameraManager: CameraManager,
-        selectedTimestamp: Double
+        selectedTimestamp: Double,
+        onboardingCompletion: ((Guide) -> Void)? = nil
     ) {
         self.clip = clip
         self.cameraSetting = cameraSetting
-        self._overlayViewModel = StateObject(wrappedValue: OverlayViewModel(clip: clip, cameraSetting: cameraSetting, cameraManager: cameraManager, selectedTimestamp: selectedTimestamp))
+        self.onboardingCompletion = onboardingCompletion
+        self._overlayViewModel = StateObject(
+            wrappedValue: OverlayViewModel(
+                clip: clip,
+                cameraSetting: cameraSetting,
+                cameraManager: cameraManager,
+                selectedTimestamp: selectedTimestamp
+            )
+        )
     }
 
     var body: some View {
@@ -111,7 +121,14 @@ struct OverlayView: View {
             if overlayViewModel.isOverlayReady && overlayViewModel.outlineImage != nil {
                 Button(action: {
                     let projectID = overlayViewModel.saveProjectData()
+                    
                     if let guide = overlayViewModel.guide {
+                        
+                        if let onboardingCompletion {
+                            onboardingCompletion(guide)
+                            return
+                        }
+                        
                         coordinator.push(
                             .projectEdit(
                                 projectID: projectID,

--- a/Chalkak/Presentation/Onboarding/OnboardingExperienceRoute.swift
+++ b/Chalkak/Presentation/Onboarding/OnboardingExperienceRoute.swift
@@ -1,0 +1,15 @@
+//
+//  OnboardingExperienceRoute.swift
+//  Chalkak
+//
+//  Created by 배현진 on 6/28/26.
+//
+
+import Foundation
+
+enum OnboardingExperienceRoute {
+    case camera
+    case clipEdit(URL, CameraSetting, CameraManager, [TimeStampedTilt])
+    case guideSelect(Clip, CameraSetting, CameraManager)
+    case overlay(Clip, CameraSetting, CameraManager, Double)
+}

--- a/Chalkak/Presentation/Onboarding/OnboardingFlowController.swift
+++ b/Chalkak/Presentation/Onboarding/OnboardingFlowController.swift
@@ -12,6 +12,7 @@ final class OnboardingFlowController: ObservableObject {
 
     @Published private(set) var currentIndex: Int
     @Published var selectedCarouselCard: OnboardingCarouselCard
+    @Published var experienceGuide: Guide?
 
     init(
         steps: [OnboardingStep] = OnboardingStep.activeSteps,

--- a/Chalkak/Presentation/Onboarding/OnboardingStep.swift
+++ b/Chalkak/Presentation/Onboarding/OnboardingStep.swift
@@ -83,7 +83,9 @@ enum OnboardingStep: CaseIterable, Equatable {
     case guideSimpleRecord
     case dailyMemoryCarousel
     case firstShootPrompt
+    case firstShootExperience
     case guideShootPrompt
+    case followUpShootExperience
     case shootDone
     case projectContinue
 
@@ -92,7 +94,9 @@ enum OnboardingStep: CaseIterable, Equatable {
         .guideSimpleRecord,
         .dailyMemoryCarousel,
         .firstShootPrompt,
+        .firstShootExperience,
         .guideShootPrompt,
+        .followUpShootExperience,
         .shootDone,
         .projectContinue
     ]
@@ -104,6 +108,8 @@ enum OnboardingStep: CaseIterable, Equatable {
         case .guideSimpleRecord:
             .automatic(delay: 3.0)
         case .dailyMemoryCarousel, .firstShootPrompt, .guideShootPrompt:
+            .manual
+        case .firstShootExperience, .followUpShootExperience:
             .manual
         case .shootDone:
             .typingAutomatic
@@ -161,6 +167,8 @@ enum OnboardingStep: CaseIterable, Equatable {
                 "나의 프로젝트에서",
                 "오늘 하루를 완성해보세요!"
             ]
+        case .firstShootExperience, .followUpShootExperience:
+            []
         }
     }
 }

--- a/Chalkak/Presentation/Onboarding/OnboardingStep.swift
+++ b/Chalkak/Presentation/Onboarding/OnboardingStep.swift
@@ -84,7 +84,6 @@ enum OnboardingStep: CaseIterable, Equatable {
     case dailyMemoryCarousel
     case firstShootPrompt
     case firstShootExperience
-    case guideShootPrompt
     case followUpShootExperience
     case shootDone
     case projectContinue
@@ -95,7 +94,6 @@ enum OnboardingStep: CaseIterable, Equatable {
         .dailyMemoryCarousel,
         .firstShootPrompt,
         .firstShootExperience,
-        .guideShootPrompt,
         .followUpShootExperience,
         .shootDone,
         .projectContinue
@@ -107,7 +105,7 @@ enum OnboardingStep: CaseIterable, Equatable {
             .automatic(delay: 2.2)
         case .guideSimpleRecord:
             .automatic(delay: 3.0)
-        case .dailyMemoryCarousel, .firstShootPrompt, .guideShootPrompt:
+        case .dailyMemoryCarousel, .firstShootPrompt:
             .manual
         case .firstShootExperience, .followUpShootExperience:
             .manual
@@ -153,11 +151,6 @@ enum OnboardingStep: CaseIterable, Equatable {
                     "첫 촬영을 시작해볼까요 ?"
                 ]
             }
-        case .guideShootPrompt:
-            [
-                "가이드에 맞춰",
-                "다른 장면을 찍어주세요"
-            ]
         case .shootDone:
             [
                 "촬영 끝!"

--- a/Chalkak/Presentation/Onboarding/OnboardingView.swift
+++ b/Chalkak/Presentation/Onboarding/OnboardingView.swift
@@ -99,13 +99,6 @@ private struct KoreanOnboardingFlowView: View {
                     controller.moveBack()
                 }
             )
-        case .guideShootPrompt:
-            OnboardingGuideShootPromptStepView(
-                lines: controller.currentStep.prompt(for: controller.selectedCarouselCard),
-                frameImageNames: (1...17).map { "c-\($0)" }
-            ) {
-                handleCenteredPromptAction()
-            }
         case .followUpShootExperience:
             if let guide = controller.experienceGuide {
                 OnboardingFollowUpShootExperienceView(
@@ -133,7 +126,6 @@ private struct KoreanOnboardingFlowView: View {
 
     private var shouldShowPrimaryButton: Bool {
         guard controller.currentStep != .firstShootPrompt,
-              controller.currentStep != .guideShootPrompt,
               controller.currentStep != .firstShootExperience,
               controller.currentStep != .followUpShootExperience,
               controller.currentStep != .shootDone else {

--- a/Chalkak/Presentation/Onboarding/OnboardingView.swift
+++ b/Chalkak/Presentation/Onboarding/OnboardingView.swift
@@ -89,12 +89,36 @@ private struct KoreanOnboardingFlowView: View {
             ) {
                 handleCenteredPromptAction()
             }
+        case .firstShootExperience:
+            OnboardingFirstShootExperienceView(
+                onFinished: { guide in
+                    controller.experienceGuide = guide
+                    controller.moveNext()
+                },
+                onExit: {
+                    controller.moveBack()
+                }
+            )
         case .guideShootPrompt:
             OnboardingGuideShootPromptStepView(
                 lines: controller.currentStep.prompt(for: controller.selectedCarouselCard),
                 frameImageNames: (1...17).map { "c-\($0)" }
             ) {
                 handleCenteredPromptAction()
+            }
+        case .followUpShootExperience:
+            if let guide = controller.experienceGuide {
+                OnboardingFollowUpShootExperienceView(
+                    guide: guide,
+                    onFinished: {
+                        controller.moveNext()
+                    },
+                    onExit: {
+                        controller.moveBack()
+                    }
+                )
+            } else {
+                OnboardingTextStepView(lines: ["가이드 생성에 실패했어요"])
             }
         case .shootDone:
             OnboardingTypingTextStepView(
@@ -110,12 +134,14 @@ private struct KoreanOnboardingFlowView: View {
     private var shouldShowPrimaryButton: Bool {
         guard controller.currentStep != .firstShootPrompt,
               controller.currentStep != .guideShootPrompt,
-              controller.currentStep != .shootDone else { return false }
+              controller.currentStep != .firstShootExperience,
+              controller.currentStep != .followUpShootExperience,
+              controller.currentStep != .shootDone else {
+            return false
+        }
 
         return switch controller.advanceBehavior {
-        case .automatic:
-            false
-        case .typingAutomatic:
+        case .automatic, .typingAutomatic:
             false
         case .manual, .completion:
             true

--- a/Chalkak/Presentation/Onboarding/SubViews/OnboardingEditorTooltip.swift
+++ b/Chalkak/Presentation/Onboarding/SubViews/OnboardingEditorTooltip.swift
@@ -1,0 +1,28 @@
+//
+//  OnboardingEditorTooltip.swift
+//  Chalkak
+//
+//  Created by 배현진 on 6/28/26.
+//
+
+import SwiftUI
+
+struct OnboardingEditorTooltip: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(SnappieColor.labelDarkNormal)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(SnappieColor.tooltipBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(alignment: .bottomLeading) {
+                TooltipTriangleShape()
+                    .fill(SnappieColor.primaryNormal)
+                    .frame(width: 14, height: 10)
+                    .offset(x: 18, y: 9)
+            }
+    }
+}

--- a/Chalkak/Presentation/Onboarding/SubViews/OnboardingFirstShootExperienceView.swift
+++ b/Chalkak/Presentation/Onboarding/SubViews/OnboardingFirstShootExperienceView.swift
@@ -1,0 +1,69 @@
+//
+//  OnboardingFirstShootExperienceView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 6/28/26.
+//
+
+import SwiftUI
+
+struct OnboardingFirstShootExperienceView: View {
+    let onFinished: (Guide) -> Void
+    let onExit: () -> Void
+    
+    @State private var route: OnboardingExperienceRoute = .camera
+
+    var body: some View {
+        switch route {
+        case .camera:
+            FirstShootCameraView(
+                onboardingVideoSaved: { url, setting, manager, tiltList in
+                    route = .clipEdit(url, setting, manager, tiltList)
+                },
+                onboardingExit: {
+                    onExit()
+                }
+            )
+
+        case let .clipEdit(url, setting, manager, tiltList):
+            ClipEditView(
+                clipURL: url,
+                shootState: .firstShoot,
+                cameraSetting: setting,
+                cameraManager: manager,
+                timeStampedTiltList: tiltList,
+                onboardingCompletion: { clip, setting, manager in
+                    route = .guideSelect(clip, setting, manager)
+                },
+                onboardingBack: {
+                    route = .camera
+                }
+            )
+
+        case let .guideSelect(clip, setting, manager):
+            GuideSelectView(
+                clip: clip,
+                shootState: .firstShoot,
+                cameraSetting: setting,
+                cameraManager: manager,
+                onboardingCompletion: { selectedTimestamp in
+                    route = .overlay(clip, setting, manager, selectedTimestamp)
+                },
+                onboardingBack: {
+                    route = .clipEdit(clip.videoURL, setting, manager, clip.tiltList)
+                }
+            )
+
+        case let .overlay(clip, setting, manager, selectedTimestamp):
+            OverlayView(
+                clip: clip,
+                cameraSetting: setting,
+                cameraManager: manager,
+                selectedTimestamp: selectedTimestamp,
+                onboardingCompletion: { guide in
+                    onFinished(guide)
+                }
+            )
+        }
+    }
+}

--- a/Chalkak/Presentation/Onboarding/SubViews/OnboardingFollowUpShootExperienceView.swift
+++ b/Chalkak/Presentation/Onboarding/SubViews/OnboardingFollowUpShootExperienceView.swift
@@ -13,8 +13,33 @@ struct OnboardingFollowUpShootExperienceView: View {
     let onExit: () -> Void
 
     @State private var route: OnboardingExperienceRoute = .camera
+    @State private var isGuidePromptPresented = true
 
     var body: some View {
+        ZStack {
+            content
+
+            if isGuidePromptPresented {
+                OnboardingGuideCameraPromptOverlay(
+                    lines: [
+                        "가이드에 맞춰",
+                        "다른 장면을 찍어주세요"
+                    ],
+                    frameImageNames: (1...17).map { "c-\($0)" }
+                ) {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        isGuidePromptPresented = false
+                    }
+                }
+                .transition(.opacity)
+                .zIndex(10)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: isGuidePromptPresented)
+    }
+
+    @ViewBuilder
+    private var content: some View {
         switch route {
         case .camera:
             GuideCameraView(
@@ -35,12 +60,12 @@ struct OnboardingFollowUpShootExperienceView: View {
                 cameraSetting: setting,
                 cameraManager: manager,
                 timeStampedTiltList: tiltList,
-                onboardingCompletion: nil,
                 onboardingFinishShoot: {
                     onFinished()
                 },
                 onboardingBack: {
                     route = .camera
+                    isGuidePromptPresented = false
                 }
             )
 

--- a/Chalkak/Presentation/Onboarding/SubViews/OnboardingFollowUpShootExperienceView.swift
+++ b/Chalkak/Presentation/Onboarding/SubViews/OnboardingFollowUpShootExperienceView.swift
@@ -1,0 +1,51 @@
+//
+//  OnboardingFollowUpShootExperienceView.swift
+//  Chalkak
+//
+//  Created by 배현진 on 6/28/26.
+//
+
+import SwiftUI
+
+struct OnboardingFollowUpShootExperienceView: View {
+    let guide: Guide
+    let onFinished: () -> Void
+    let onExit: () -> Void
+
+    @State private var route: OnboardingExperienceRoute = .camera
+
+    var body: some View {
+        switch route {
+        case .camera:
+            GuideCameraView(
+                guide: guide,
+                shootState: .followUpShoot(guide: guide),
+                onboardingVideoSaved: { url, setting, manager, tiltList in
+                    route = .clipEdit(url, setting, manager, tiltList)
+                },
+                onboardingExit: {
+                    onExit()
+                }
+            )
+
+        case let .clipEdit(url, setting, manager, tiltList):
+            ClipEditView(
+                clipURL: url,
+                shootState: .followUpShoot(guide: guide),
+                cameraSetting: setting,
+                cameraManager: manager,
+                timeStampedTiltList: tiltList,
+                onboardingCompletion: nil,
+                onboardingFinishShoot: {
+                    onFinished()
+                },
+                onboardingBack: {
+                    route = .camera
+                }
+            )
+
+        default:
+            EmptyView()
+        }
+    }
+}

--- a/Chalkak/Presentation/Onboarding/SubViews/OnboardingGuideCameraPromptOverlay.swift
+++ b/Chalkak/Presentation/Onboarding/SubViews/OnboardingGuideCameraPromptOverlay.swift
@@ -1,0 +1,41 @@
+//
+//  OnboardingGuideCameraPromptOverlay.swift
+//  Chalkak
+//
+//  Created by 배현진 on 6/28/26.
+//
+
+import SwiftUI
+
+struct OnboardingGuideCameraPromptOverlay: View {
+    let lines: [String]
+    let frameImageNames: [String]
+    let action: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .opacity(0.9)
+                .ignoresSafeArea()
+
+            VStack(spacing: 75) {
+                VStack(spacing: 32) {
+                    OnboardingFrameAnimationView(imageNames: frameImageNames)
+
+                    VStack(spacing: 10) {
+                        ForEach(lines, id: \.self) { line in
+                            Text(line)
+                                .font(.system(size: 24, weight: .bold))
+                                .foregroundStyle(SnappieColor.labelPrimaryNormal)
+                                .multilineTextAlignment(.center)
+                        }
+                    }
+                }
+
+                OnboardingPrimaryButton(title: "확인", action: action)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, 24)
+        }
+    }
+}


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #113 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.
- 온보딩 플로우에 촬영 체험 플로우 추가
- 온보딩 찰영 시점에 권한 요청
- 온보딩 툴팁 기능 추가
- 온보딩 수행내용 실제 프로젝트에 저장
- 가이드 관련 온보딩 UI 수정

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

용량 문제로 노션에 영상 올렸습니다.

https://www.notion.so/msseock/38d7a645e61c806fa7cde7508e633e6f?source=copy_link


## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

- 촬영 체험 과정 구현 방식
저희가 의논 후 결정했던 방식은 온보딩에서 사용할 화면용 코드를 새롭게 만들자는 것이었습니다.
오히려 빠른 시간 내에 수행할 수 있을 것이라고 생각했기 때문이었는데요.
실제로 구조를 구상하다보니, 기존 코드를 활용하는 것이 훨씬 적합할것같아 해당 방식으로 구현하였습니다.
기존 카메라, 클립편집, 가이드선택, 오버레이 화면들에 온보딩 조건을 활용하여 구현하였습니다.

- 툴팁 구현
현재 대부분 툴팁을 Tipkit을 활용하고 있습니다.
온보딩 UI에서 커스텀 형태를 하고있기도 하고, 설계 구조 자체가 커스텀이 적합해보여 SwiftUI 활용한 커스텀 툴팁 구현해 활용했습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
