### PR TITLE
🐛 [Fix] 가이드 편집 변경사항으로 추적

### DIFF
--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -78,30 +78,48 @@ final class ProjectEditViewModel {
     // MARK: - 비동기 로딩 메서드
 
     func loadProject() async {
-        let prevClips = editableClips
-        let prevGuideTimestamp = guide?.selectedTimestamp
-
         isLoading = true
         await loadProjectData()
         isLoading = false
 
-        // projectEditView뿐만아니라, 클립 편집 / 가이드 같이 다른 뷰로 이탈해서 변경하고 돌아오는 것 감지
-        if isAlreadyInitialized, !prevClips.isEmpty {
-            if prevClips.count != editableClips.count {
-                hasUnsavedChanges = true
-            } else {
-                for (prev, curr) in zip(prevClips, editableClips) {
-                    if prev.id == curr.id,
-                       prev.startPoint != curr.startPoint || prev.endPoint != curr.endPoint
-                    {
-                        hasUnsavedChanges = true
-                        break
-                    }
-                }
-            }
-            if guide?.selectedTimestamp != prevGuideTimestamp {
-                hasUnsavedChanges = true
-            }
+        // temp ↔ 원본 변경사항 감지
+        hasUnsavedChanges = computeHasUnsavedChanges()
+    }
+
+    /// temp 프로젝트가 원본과 달라졌는지 직접 비교해 변경 여부를 판단한다.
+    private func computeHasUnsavedChanges() -> Bool {
+        guard let tempProject = SwiftDataManager.shared.fetchProject(byID: projectID),
+              tempProject.isTemp,
+              let originalID = tempProject.originalID,
+              let originalProject = SwiftDataManager.shared.fetchProject(byID: originalID)
+        else {
+            return false // temp가 아니면 비교 대상이 없음 = 변경 없음
+        }
+
+        // 가이드 변경 (선택 타임스탬프)
+        if tempProject.guide.selectedTimestamp != originalProject.guide.selectedTimestamp {
+            return true
+        }
+
+        // 클립 변경 (개수 / 순서 / 트리밍 구간)
+        let tempOrdered = sortedByTimelineOrder(tempProject.clipList)
+        let originalOrdered = sortedByTimelineOrder(originalProject.clipList)
+
+        if tempOrdered.count != originalOrdered.count { return true }
+
+        for (temp, original) in zip(tempOrdered, originalOrdered) {
+            // 새로 추가됐거나(originalClipID == nil) 순서가 바뀌면 원본 매핑이 어긋남
+            if temp.originalClipID != original.id { return true }
+            if temp.startPoint != original.startPoint || temp.endPoint != original.endPoint { return true }
+        }
+
+        return false
+    }
+
+    private func sortedByTimelineOrder(_ clips: [Clip]) -> [Clip] {
+        clips.sorted {
+            if $0.order != $1.order { return $0.order < $1.order }
+            return $0.createdAt < $1.createdAt
         }
     }
 

--- a/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
+++ b/Chalkak/Presentation/ProjectEdit/ProjectEditViewModel.swift
@@ -335,24 +335,9 @@ final class ProjectEditViewModel {
                 self.playHead = secs
                 Task { await self.updatePreviewImage(at: secs) }
 
-                // 기존 트리밍 로직도 그대로 유지
-                if let clip = self.editableClips.first(where: { $0.isTrimming }) {
-                    let allStart = self.allClipStart(of: clip)
-                    let allEnd = allStart + clip.trimmedDuration
-                    if secs >= allEnd {
-                        self.player.seek(
-                            to: CMTime(seconds: allStart, preferredTimescale: 600),
-                            toleranceBefore: .zero, toleranceAfter: .zero
-                        )
-                        if self.isPlaying {
-                            self.player.play()
-                        }
-                    }
-                } else {
-                    if secs >= self.totalDuration {
-                        self.isPlaying = false
-                        self.player.pause()
-                    }
+                if secs >= self.totalDuration {
+                    self.isPlaying = false
+                    self.player.pause()
                 }
             }
         }
@@ -427,23 +412,6 @@ final class ProjectEditViewModel {
     }
 
     func togglePlayback() {
-        if let clip = editableClips.first(where: { $0.isTrimming }) {
-            let allStart = allClipStart(of: clip)
-            let allEnd = allStart + clip.trimmedDuration
-
-            if playHead < allStart || playHead >= allEnd {
-                seekTo(time: allStart)
-            }
-
-            isPlaying.toggle()
-            if isPlaying {
-                player.play()
-            } else {
-                player.pause()
-            }
-            return
-        }
-
         // 끝에 도달했을 때 0초로 리셋하지 않고 그 자리에서 정지
         if playHead >= totalDuration {
             isPlaying = false
@@ -499,39 +467,6 @@ final class ProjectEditViewModel {
             _ = await photoLibrarySaver.saveVideoToLibrary(videoURL: url)
         } catch {
             print("클립 내보내기 실패:", error)
-        }
-    }
-
-    func toggleTrimmingMode(for clipID: String) {
-        // 트리밍 모드 토글
-        editableClips = editableClips.map { clip in
-            var c = clip
-            c.isTrimming = (c.id == clipID) ? !c.isTrimming : false
-            return c
-        }
-
-        // 트리밍 모드가 활성화된 클립을 찾고, 해당 클립의 시작 위치로 플레이헤드 이동
-        if let trimmingClip = editableClips.first(where: { $0.isTrimming }) {
-            // 해당 클립의 타임라인상 시작 위치
-            let clipStartTime = allClipStart(of: trimmingClip)
-
-            // 범위 체크
-            let safeTime = min(max(0, clipStartTime), totalDuration)
-
-            // 트리밍된 부분의 시작점으로 플레이헤드 이동
-            seekTo(time: safeTime)
-
-            // 재생 중이었다면 일시정지
-            if isPlaying {
-                isPlaying = false
-                player.pause()
-            }
-        }
-    }
-
-    func deactivateAllTrimming() {
-        for i in 0 ..< editableClips.count {
-            editableClips[i].isTrimming = false
         }
     }
 


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #111 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

프로젝트 편집 화면에서 수정사항이 있을 때 저장 버튼이 비활성 상태에서 활성 상태로 변해야 하는데,
가이드를 수정하는 경우에는 해당 로직이 작동하지 않았습니다.

유저가 가이드를 바꿨을 때 이를 프로젝트 변경사항으로 추적해서 저장 버튼이 활성화되도록 수정했습니다.

## 📸 Screenshot
> 작업 화면의 스크린샷을 추가해주세요.

https://github.com/user-attachments/assets/c307ba09-054c-4d45-b83c-390d251a391f

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

1. 소정의 리팩토링이 포함되었습니다: 프로젝트 편집에서 더이상 트리밍을 직접 하지 않으면서, ProjectEditViewModel에서 트리밍중인지를 파악하는 로직이 불필요해졌음에도 아직 남아있었습니다. 사용되지 않는 코드임을 확인하고 제거하였습니다.
2. 가이드 수정이 추적되지 않았던 이유: 가이드 수정 후에 원래 ProjectEditView로 pop해서 돌아오는 구조가 아니라, 새로운 ProjectEditView가 push되어 쌓이는 구조였기 때문이었습니다.(새로운 리팩토링 수정을 해야할 지 한 번 확인해봐야 할 것 같습니다..!) 기존 코드는 변경 감지를 `이전 화면 진입 시점의 메모리 스냅샷(prevClips/prevGuideTimestamp)`이랑 `다시 로드된 값`을 비교하는 방식으로 구현해놨더라구요. 그런데 가이드 수정 플로우(ProjectEdit → GuideSelect → Overlay)는 완료 후 같은 인스턴스로 돌아오는 게 아니라 ProjectEdit이 새로 push되면서 ViewModel 인스턴스 자체가 새로 만들어지는 구조라, 비교할 이전 스냅샷이 없었습니다..!
    - 그래서 인스턴스의 메모리 상태에 의존하는 방식 대신, SwiftData에 저장된 temp 프로젝트와 원본 프로젝트를 직접 비교하는 메서드로 따로 분리해서, 화면에 어떻게 진입했든 상관없이 항상 정확하게 변경 여부를 판단하도록 수정했습니다.

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
