### PR TITLE
✨ [feat] 푸시 알람 정책에 맞춰 등록

### DIFF
--- a/Chalkak/Presentation/Onboarding/OnboardingNotificationScheduler.swift
+++ b/Chalkak/Presentation/Onboarding/OnboardingNotificationScheduler.swift
@@ -14,6 +14,8 @@ enum OnboardingNotificationSchedulePolicy {
 
     private static let eveningCutoffHour = 18
     private static let maxNotificationCount = 24
+    private static let notificationIntervalHours = 2
+    private static let quietHourEnd = 8 // 00:00~08:00 알림 제외
 
     static func scheduledDates(
         from startDate: Date,
@@ -21,14 +23,16 @@ enum OnboardingNotificationSchedulePolicy {
     ) -> [Date] {
         let endDate = scheduleEndDate(from: startDate, calendar: calendar)
         var dates: [Date] = []
-        var nextDate = calendar.date(byAdding: .hour, value: 1, to: startDate)
+        var nextDate = calendar.date(byAdding: .hour, value: notificationIntervalHours, to: startDate)
 
         while let date = nextDate,
               date <= endDate,
               dates.count < maxNotificationCount
         {
-            dates.append(date)
-            nextDate = calendar.date(byAdding: .hour, value: 1, to: date)
+            if calendar.component(.hour, from: date) >= quietHourEnd {
+                dates.append(date)
+            }
+            nextDate = calendar.date(byAdding: .hour, value: notificationIntervalHours, to: date)
         }
 
         return dates


### PR DESCRIPTION
## 🔖  해결한 이슈 
<!-- 해결한 이슈 번호를 작성해주세요 (Ex. #4) -->
- Resolved: #119 

## ✨ PR Content
> 작업 내용 설명을 적어주세요.

임의로 1시간에 한 번 보내던 유저 알림을 아래의 정책에 맞춰서 등록하는 방식으로 로직을 수정했습니다.
- 하루 동안(알림 허용 시각 ~ 밤 12시), 두 시간에 한 번 푸시 알림
- 알림 허용 시각이 오후 6시 이후라면, 알림 시간대 변경(알람 허용 시각 ~ 다음날 해당 시각)
- 밤 12시 ~ 아침 8시까지는 알림 X

## 📍 PR Point 
> 팀원에게 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성해주세요

아래 사항들을 수정했습니다!
- 1시간에서 2시간에 한 번 빈도로 수정
- 새벽시간을 필터링해서 0시~8시 알림 제외

## ✅ Checklist
- [x] Merge 하는 브랜치가 올바른지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] PR과 관련없는 변경사항 없는지 확인
- [x] 컨벤션 지켰는지 확인
